### PR TITLE
add support for showing end address of modules

### DIFF
--- a/ui/moduleswidget.cpp
+++ b/ui/moduleswidget.cpp
@@ -412,7 +412,7 @@ void DebugModulesWidget::jumpToStart()
 		return;
 
 	auto module = m_model->getRow(sourceIndex.row());
-	uint64_t adderss = module.address();
+	uint64_t address = module.address();
 
 	UIContext* context = UIContext::contextForWidget(this);
 	if (!context)
@@ -423,9 +423,9 @@ void DebugModulesWidget::jumpToStart()
 		return;
 
 	if (m_controller->GetLiveView())
-		frame->navigate(m_controller->GetLiveView(), adderss, true, true);
+		frame->navigate(m_controller->GetLiveView(), address, true, true);
 	else
-		frame->navigate(m_controller->GetData(), adderss, true, true);
+		frame->navigate(m_controller->GetData(), address, true, true);
 }
 
 
@@ -440,7 +440,7 @@ void DebugModulesWidget::jumpToEnd()
 		return;
 
 	auto module = m_model->getRow(sourceIndex.row());
-	uint64_t adderss = module.endAddress();
+	uint64_t address = module.endAddress();
 
 	UIContext* context = UIContext::contextForWidget(this);
 	if (!context)
@@ -451,9 +451,9 @@ void DebugModulesWidget::jumpToEnd()
 		return;
 
 	if (m_controller->GetLiveView())
-		frame->navigate(m_controller->GetLiveView(), adderss, true, true);
+		frame->navigate(m_controller->GetLiveView(), address, true, true);
 	else
-		frame->navigate(m_controller->GetData(), adderss, true, true);
+		frame->navigate(m_controller->GetData(), address, true, true);
 }
 
 

--- a/ui/moduleswidget.h
+++ b/ui/moduleswidget.h
@@ -83,7 +83,7 @@ public:
 
     virtual int rowCount(const QModelIndex& parent = QModelIndex()) const override
         { (void) parent; return (int)m_items.size(); }
-    virtual int columnCount(const QModelIndex& parent = QModelIndex()) const override { (void) parent; return 4; }
+    virtual int columnCount(const QModelIndex& parent = QModelIndex()) const override { (void) parent; return 5; }
     ModuleItem getRow(int row) const;
     virtual QVariant data(const QModelIndex& i, int role) const override;
     virtual QVariant headerData(int column, Qt::Orientation orientation, int role) const override;

--- a/ui/moduleswidget.h
+++ b/ui/moduleswidget.h
@@ -45,6 +45,7 @@ private:
 public:
     ModuleItem(uint64_t address, size_t size, std::string name, std::string path);
     uint64_t address() const { return m_address; }
+    uint64_t endAddress() const { return m_address + m_size; }
     size_t size() const { return m_size; }
     std::string name() const { return m_name; }
     std::string path() const { return m_path; }
@@ -69,6 +70,7 @@ public:
     enum ColumnHeaders
     {
         AddressColumn,
+        EndAddressColumn,
         SizeColumn,
         NameColumn,
         PathColumn,


### PR DESCRIPTION
Tried to fix #241.

I think renaming "address" to "base" and "end address" to "end" would be good idea. I didn't do it because I wasn't sure if you would like it.