### PR TITLE
thread suspend resume support

### DIFF
--- a/api/debuggerapi.h
+++ b/api/debuggerapi.h
@@ -276,6 +276,7 @@ namespace BinaryNinjaDebuggerAPI {
 	{
 		std::uint32_t m_tid {};
 		std::uintptr_t m_rip {};
+		bool m_isFrozen {};
 
 		DebugThread() {}
 		DebugThread(std::uint32_t tid) : m_tid(tid) {}
@@ -452,6 +453,8 @@ namespace BinaryNinjaDebuggerAPI {
 		DebugThread GetActiveThread();
 		void SetActiveThread(const DebugThread& thread);
 		std::vector<DebugFrame> GetFramesOfThread(uint32_t tid);
+		bool SuspendThread(std::uint32_t tid);
+		bool ResumeThread(std::uint32_t tid);
 
 		std::vector<DebugModule> GetModules();
 		std::vector<DebugRegister> GetRegisters();

--- a/api/debuggercontroller.cpp
+++ b/api/debuggercontroller.cpp
@@ -123,6 +123,7 @@ std::vector<DebugThread> DebuggerController::GetThreads()
 		DebugThread thread;
 		thread.m_rip = threads[i].m_rip;
 		thread.m_tid = threads[i].m_tid;
+		thread.m_isFrozen = threads[i].m_isFrozen;
 		result.push_back(thread);
 	}
 	BNDebuggerFreeThreads(threads, count);
@@ -147,6 +148,18 @@ void DebuggerController::SetActiveThread(const DebugThread& thread)
 	activeThread.m_rip = thread.m_rip;
 	activeThread.m_tid = thread.m_tid;
 	BNDebuggerSetActiveThread(m_object, activeThread);
+}
+
+
+bool DebuggerController::SuspendThread(std::uint32_t tid)
+{
+	return BNDebuggerSuspendThread(m_object, tid);
+}
+
+
+bool DebuggerController::ResumeThread(std::uint32_t tid)
+{
+	return BNDebuggerResumeThread(m_object, tid);
 }
 
 

--- a/api/ffi.h
+++ b/api/ffi.h
@@ -58,6 +58,7 @@ extern "C"
 	{
 		uint32_t m_tid;
 		uint64_t m_rip;
+		bool m_isFrozen;
 	};
 
 	struct BNDebugFrame
@@ -227,6 +228,7 @@ extern "C"
 		// This event is only emitted when the value of a register is modified explicitly (e.g., using Python API,
 		// in the register widget, etc.). It is not emitted when the target executes and then stops.
 		RegisterChangedEvent,
+		ThreadStateChangedEvent,
 	};
 
 
@@ -319,6 +321,8 @@ extern "C"
 
 	DEBUGGER_FFI_API BNDebugThread BNDebuggerGetActiveThread(BNDebuggerController* controller);
 	DEBUGGER_FFI_API void BNDebuggerSetActiveThread(BNDebuggerController* controller, BNDebugThread thread);
+	DEBUGGER_FFI_API bool BNDebuggerSuspendThread(BNDebuggerController* controller, uint32_t tid);
+	DEBUGGER_FFI_API bool BNDebuggerResumeThread(BNDebuggerController* controller, uint32_t tid);
 
 	DEBUGGER_FFI_API BNDebugFrame* BNDebuggerGetFramesOfThread(
 		BNDebuggerController* controller, uint32_t tid, size_t* count);

--- a/api/python/debuggercontroller.py
+++ b/api/python/debuggercontroller.py
@@ -585,6 +585,24 @@ class DebuggerController:
     def active_thread(self, thread: DebugThread) -> None:
         dbgcore.BNDebuggerSetActiveThread(self.handle, dbgcore.BNDebugThread(thread.tid, thread.rip))
 
+    def suspend_thread(self, tid: int) -> bool:
+        """
+        Suspends a thread by thread id.
+
+        :param tid: thread id
+        :return:
+        """
+        return dbgcore.BNDebuggerSuspendThread(self.handle, tid)
+
+    def resume_thread(self, tid: int) -> bool:
+        """
+        Resumes a thread by thread id.
+
+        :param tid: thread id
+        :return:
+        """
+        return dbgcore.BNDebuggerResumeThread(self.handle, tid)
+
     @property
     def modules(self) -> List[DebugModule]:
         """

--- a/core/adapters/dbgengadapter.cpp
+++ b/core/adapters/dbgengadapter.cpp
@@ -633,6 +633,22 @@ bool DbgEngAdapter::SetActiveThreadId(std::uint32_t tid)
 	return true;
 }
 
+
+bool DbgEngAdapter::SuspendThread(std::uint32_t tid)
+{
+	std::string suspendCmd = fmt::format("~{}f", tid);
+	InvokeBackendCommand(suspendCmd);
+	return true;
+}
+
+bool DbgEngAdapter::ResumeThread(std::uint32_t tid)
+{
+	std::string resumeCmd = fmt::format("~{}u", tid);
+	InvokeBackendCommand(resumeCmd);
+	return true;
+}
+
+
 DebugBreakpoint DbgEngAdapter::AddBreakpoint(const std::uintptr_t address, unsigned long breakpoint_flags)
 {
 	IDebugBreakpoint2* debug_breakpoint {};

--- a/core/adapters/dbgengadapter.h
+++ b/core/adapters/dbgengadapter.h
@@ -191,6 +191,9 @@ namespace BinaryNinjaDebugger {
 
 		std::vector<DebugFrame> GetFramesOfThread(uint32_t tid) override;
 
+		bool SuspendThread(std::uint32_t tid) override;
+		bool ResumeThread(std::uint32_t tid) override;
+
 		void ApplyBreakpoints();
 
 		std::string GetDbgEngPath(const std::string& arch = "x64");

--- a/core/adapters/lldbadapter.cpp
+++ b/core/adapters/lldbadapter.cpp
@@ -433,6 +433,39 @@ bool LldbAdapter::SetActiveThreadId(std::uint32_t tid)
 }
 
 
+bool LldbAdapter::SuspendThread(std::uint32_t tid)
+{
+	SBError error;
+	SBThread thread = m_process.GetThreadByID(tid);
+	if (!thread.IsValid())
+		return false;
+	
+	if (!thread.Suspend(error))
+		return false;
+
+	if (!error.Success())
+		return false;
+	
+	return true;
+}
+
+bool LldbAdapter::ResumeThread(std::uint32_t tid)
+{
+	SBError error;
+	SBThread thread = m_process.GetThreadByID(tid);
+	if (!thread.IsValid())
+		return false;
+	
+	if (!thread.Resume(error))
+		return false;
+
+	if (!error.Success())
+		return false;
+
+	return true;
+}
+
+
 std::vector<DebugFrame> LldbAdapter::GetFramesOfThread(uint32_t tid)
 {
 	size_t threadCount = m_process.GetNumThreads();

--- a/core/adapters/lldbadapter.h
+++ b/core/adapters/lldbadapter.h
@@ -63,6 +63,9 @@ namespace BinaryNinjaDebugger {
 
 		bool SetActiveThreadId(std::uint32_t tid) override;
 
+		bool SuspendThread(std::uint32_t tid) override;
+		bool ResumeThread(std::uint32_t tid) override;
+
 		std::vector<DebugFrame> GetFramesOfThread(uint32_t tid) override;
 
 		DebugBreakpoint AddBreakpoint(const std::uintptr_t address, unsigned long breakpoint_type) override;

--- a/core/debugadapter.h
+++ b/core/debugadapter.h
@@ -71,6 +71,7 @@ namespace BinaryNinjaDebugger {
 	{
 		std::uint32_t m_tid {};
 		std::uintptr_t m_rip {};
+		bool m_isFrozen {};
 
 		DebugThread() {}
 
@@ -210,6 +211,10 @@ namespace BinaryNinjaDebugger {
 		virtual bool SetActiveThread(const DebugThread& thread) = 0;
 
 		virtual bool SetActiveThreadId(std::uint32_t tid) = 0;
+
+		virtual bool SuspendThread(std::uint32_t tid) = 0;
+
+		virtual bool ResumeThread(std::uint32_t tid) = 0;
 
 		virtual std::vector<DebugFrame> GetFramesOfThread(std::uint32_t tid);
 

--- a/core/debuggercontroller.cpp
+++ b/core/debuggercontroller.cpp
@@ -673,6 +673,33 @@ void DebuggerController::SetActiveThread(const DebugThread& thread)
 }
 
 
+bool DebuggerController::SuspendThread(std::uint32_t tid)
+{
+	auto result = m_state->GetThreads()->SuspendThread(tid);
+	if (!result)
+		return false;
+
+	DebuggerEvent event;
+	event.type = ThreadStateChangedEvent;
+	PostDebuggerEvent(event);
+
+	return result;
+}
+
+bool DebuggerController::ResumeThread(std::uint32_t tid)
+{
+	auto result = m_state->GetThreads()->ResumeThread(tid);
+	if (!result)
+		return false;
+	
+	DebuggerEvent event;
+	event.type = ThreadStateChangedEvent;
+	PostDebuggerEvent(event);
+
+	return result;
+}
+
+
 std::vector<DebugFrame> DebuggerController::GetFramesOfThread(uint64_t tid)
 {
 	return m_state->GetThreads()->GetFramesOfThread(tid);

--- a/core/debuggercontroller.h
+++ b/core/debuggercontroller.h
@@ -156,6 +156,8 @@ namespace BinaryNinjaDebugger {
 		void SetActiveThread(const DebugThread& thread);
 		std::vector<DebugThread> GetAllThreads();
 		std::vector<DebugFrame> GetFramesOfThread(uint64_t tid);
+		bool SuspendThread(std::uint32_t tid);
+		bool ResumeThread(std::uint32_t tid);
 
 		// modules
 		std::vector<DebugModule> GetAllModules();

--- a/core/debuggerstate.h
+++ b/core/debuggerstate.h
@@ -113,6 +113,8 @@ namespace BinaryNinjaDebugger {
 		bool IsDirty() const { return m_dirty; }
 		std::vector<DebugThread> GetAllThreads();
 		std::vector<DebugFrame> GetFramesOfThread(uint32_t tid);
+		bool SuspendThread(std::uint32_t tid);
+		bool ResumeThread(std::uint32_t tid);
 	};
 
 

--- a/core/ffi.cpp
+++ b/core/ffi.cpp
@@ -210,6 +210,7 @@ BNDebugThread* BNDebuggerGetThreads(BNDebuggerController* controller, size_t* si
 	{
 		results[i].m_tid = threads[i].m_tid;
 		results[i].m_rip = threads[i].m_rip;
+		results[i].m_isFrozen = threads[i].m_isFrozen;
 	}
 
 	return results;
@@ -239,6 +240,18 @@ void BNDebuggerSetActiveThread(BNDebuggerController* controller, BNDebugThread t
 	activeThread.m_tid = thread.m_tid;
 
 	controller->object->SetActiveThread(activeThread);
+}
+
+
+bool BNDebuggerSuspendThread(BNDebuggerController* controller, uint32_t tid)
+{
+	return controller->object->SuspendThread(tid);
+}
+
+
+bool BNDebuggerResumeThread(BNDebuggerController* controller, uint32_t tid)
+{
+	return controller->object->ResumeThread(tid);
 }
 
 

--- a/ui/threadframes.cpp
+++ b/ui/threadframes.cpp
@@ -15,104 +15,114 @@ limitations under the License.
 */
 
 #include "threadframes.h"
-#include "binaryninjaapi.h"
-#include "debuggerapi.h"
-#include "inttypes.h"
 
-
-constexpr int SortFilterRole = Qt::UserRole + 1;
-
-FrameItem::FrameItem(int index, std::string module, std::string function, uint64_t pc, uint64_t sp, uint64_t fp) :
-	m_frameIndex(index), m_module(module), m_function(function), m_pc(pc), m_sp(sp), m_fp(fp)
-{}
-
-
-bool FrameItem::operator==(const FrameItem& other) const
+FrameItem::~FrameItem()
 {
-	return (m_module == other.module()) && (m_function == other.function()) && (m_pc == other.pc())
-		&& (m_fp == other.fp()) && (m_sp == other.sp());
+	qDeleteAll(m_childItems);
 }
 
 
-bool FrameItem::operator!=(const FrameItem& other) const
+void FrameItem::appendChild(FrameItem* item)
 {
-	return !(*this == other);
+	m_childItems.append(item);
 }
 
 
-bool FrameItem::operator<(const FrameItem& other) const
+FrameItem* FrameItem::child(int row)
 {
-	if (m_module < other.module())
-		return true;
-	else if (m_module > other.module())
-		return false;
-	else if (m_function < other.function())
-		return true;
-	else if (m_function > other.function())
-		return false;
-	else if (m_pc < other.pc())
-		return true;
-	else if (m_pc > other.pc())
-		return false;
-	else if (m_sp < other.sp())
-		return true;
-	else if (m_sp > other.sp())
-		return false;
-	return m_fp < other.fp();
+	if (row < 0 || row >= m_childItems.size())
+		return nullptr;
+	return m_childItems.at(row);
 }
 
 
-ThreadFramesListModel::ThreadFramesListModel(QWidget* parent, ViewFrame* view) :
-	QAbstractTableModel(parent), m_view(view)
-{}
-
-
-ThreadFramesListModel::~ThreadFramesListModel() {}
-
-
-FrameItem ThreadFramesListModel::getRow(int row) const
+int FrameItem::childCount() const
 {
-	if ((size_t)row >= m_items.size())
-		throw std::runtime_error("row index out-of-bound");
-
-	return m_items[row];
+	return m_childItems.count();
 }
 
 
-QModelIndex ThreadFramesListModel::index(int row, int column, const QModelIndex&) const
+FrameItem* FrameItem::parentItem()
 {
-	if (row < 0 || (size_t)row >= m_items.size() || column >= columnCount())
-	{
-		return QModelIndex();
-	}
-
-	return createIndex(row, column, (void*)&m_items[row]);
+	return m_parentItem;
 }
 
 
-QVariant ThreadFramesListModel::data(const QModelIndex& index, int role) const
+int FrameItem::row() const
 {
-	if (index.column() >= columnCount() || (size_t)index.row() >= m_items.size())
+	if (m_parentItem)
+		return m_parentItem->m_childItems.indexOf(const_cast<FrameItem*>(this));
+
+	return 0;
+}
+
+
+ThreadFrameModel::ThreadFrameModel(QObject* parent, DebuggerControllerRef controller) : QAbstractItemModel(parent), m_controller(controller)
+{
+	rootItem = new FrameItem();
+}
+
+
+ThreadFrameModel::~ThreadFrameModel()
+{
+	delete rootItem;
+}
+
+
+QVariant ThreadFrameModel::data(const QModelIndex& index, int role) const
+{
+	if (!index.isValid())
+		return QVariant();
+
+	if (role != Qt::DisplayRole && role != Qt::SizeHintRole)
+		return QVariant();
+
+	if (index.column() >= columnCount())
 		return QVariant();
 
 	FrameItem* item = static_cast<FrameItem*>(index.internalPointer());
 	if (!item)
 		return QVariant();
 
-	if ((role != Qt::DisplayRole) && (role != Qt::SizeHintRole) && (role != SortFilterRole))
+	// do not use columns other than thread info & state for thread rows
+	if (!item->isFrame() && index.column() > ThreadFrameModel::ThreadColumn)
 		return QVariant();
 
 	switch (index.column())
 	{
-	case ThreadFramesListModel::IndexColumn:
+	case ThreadFrameModel::StateColumn:
 	{
-		QString text = QString::asprintf("%d", item->frameIndex());
+		if (item->isFrame())
+			return QVariant();
+
+		QString text = item->isFrozen() ? "Frozen" : "Unfrozen";
 		if (role == Qt::SizeHintRole)
 			return QVariant((qulonglong)text.size());
 
 		return QVariant(text);
 	}
-	case ThreadFramesListModel::ModuleColumn:
+	case ThreadFrameModel::ThreadColumn:
+	{
+		if (item->isFrame())
+			return QVariant();
+
+		auto isActiveThread = m_controller->GetActiveThread().m_tid == item->tid();
+
+		QString text = QString::asprintf("%s0x%x @ 0x%" PRIx64, isActiveThread ? "(*) " : "", item->tid(), item->threadPc());
+		if (role == Qt::SizeHintRole)
+			return QVariant((qulonglong)text.size());
+
+		return QVariant(text);
+	}
+	case ThreadFrameModel::FrameIndexColumn:
+	{
+		QString text = QString::asprintf("%lu", item->frameIndex());
+		if (role == Qt::SizeHintRole)
+			return QVariant((qulonglong)text.size());
+
+		return QVariant(text);
+	}
+	case ThreadFrameModel::ModuleColumn:
 	{
 		QString text = QString::fromStdString(item->module());
 		if (role == Qt::SizeHintRole)
@@ -120,7 +130,7 @@ QVariant ThreadFramesListModel::data(const QModelIndex& index, int role) const
 
 		return QVariant(text);
 	}
-	case ThreadFramesListModel::FunctionColumn:
+	case ThreadFrameModel::FunctionColumn:
 	{
 		QString text = QString::fromStdString(item->function());
 		if (role == Qt::SizeHintRole)
@@ -128,15 +138,15 @@ QVariant ThreadFramesListModel::data(const QModelIndex& index, int role) const
 
 		return QVariant(text);
 	}
-	case ThreadFramesListModel::PcColumn:
+	case ThreadFrameModel::PcColumn:
 	{
-		QString text = QString::asprintf("0x%" PRIx64, item->pc());
+		QString text = QString::asprintf("0x%" PRIx64, item->framePc());
 		if (role == Qt::SizeHintRole)
 			return QVariant((qulonglong)text.size());
 
 		return QVariant(text);
 	}
-	case ThreadFramesListModel::SpColumn:
+	case ThreadFrameModel::SpColumn:
 	{
 		QString text = QString::asprintf("0x%" PRIx64, item->sp());
 		if (role == Qt::SizeHintRole)
@@ -144,7 +154,7 @@ QVariant ThreadFramesListModel::data(const QModelIndex& index, int role) const
 
 		return QVariant(text);
 	}
-	case ThreadFramesListModel::FpColumn:
+	case ThreadFrameModel::FpColumn:
 	{
 		QString text = QString::asprintf("0x%" PRIx64, item->fp());
 		if (role == Qt::SizeHintRole)
@@ -157,7 +167,40 @@ QVariant ThreadFramesListModel::data(const QModelIndex& index, int role) const
 }
 
 
-QVariant ThreadFramesListModel::headerData(int column, Qt::Orientation orientation, int role) const
+void ThreadFrameModel::updateRows(DebuggerController* controller)
+{
+	beginResetModel();
+
+	if (rootItem)
+	{
+		delete rootItem;
+		rootItem = new FrameItem();
+	}
+
+	QList<FrameItem*> parents;
+	parents << rootItem;
+
+	std::vector<DebugThread> threads = controller->GetThreads();
+	for (const DebugThread& thread : threads)
+	{
+		parents.last()->appendChild(new FrameItem(thread, parents.last()));
+
+		parents << parents.last()->child(parents.last()->childCount() - 1);
+
+		std::vector<DebugFrame> frames = controller->GetFramesOfThread(thread.m_tid);
+		for (const DebugFrame& frame : frames)
+		{
+			parents.last()->appendChild(new FrameItem(thread, frame, parents.last()));
+		}
+
+		parents.pop_back();
+	}
+
+	endResetModel();
+}
+
+
+QVariant ThreadFrameModel::headerData(int column, Qt::Orientation orientation, int role) const
 {
 	if (role != Qt::DisplayRole)
 		return QVariant();
@@ -167,43 +210,81 @@ QVariant ThreadFramesListModel::headerData(int column, Qt::Orientation orientati
 
 	switch (column)
 	{
-	case ThreadFramesListModel::IndexColumn:
-		return "#";
-	case ThreadFramesListModel::ModuleColumn:
+	case ThreadFrameModel::StateColumn:
+		return "State";
+	case ThreadFrameModel::ThreadColumn:
+		return "Thread";
+	case ThreadFrameModel::FrameIndexColumn:
+		return "Frame #";
+	case ThreadFrameModel::ModuleColumn:
 		return "Module";
-	case ThreadFramesListModel::FunctionColumn:
+	case ThreadFrameModel::FunctionColumn:
 		return "Function";
-	case ThreadFramesListModel::PcColumn:
+	case ThreadFrameModel::PcColumn:
 		return "PC";
-	case ThreadFramesListModel::SpColumn:
+	case ThreadFrameModel::SpColumn:
 		return "SP";
-	case ThreadFramesListModel::FpColumn:
+	case ThreadFrameModel::FpColumn:
 		return "FP";
 	}
+
 	return QVariant();
 }
 
 
-void ThreadFramesListModel::updateRows(std::vector<BinaryNinjaDebuggerAPI::DebugFrame> frames)
+QModelIndex ThreadFrameModel::index(int row, int column, const QModelIndex& parent) const
 {
-	beginResetModel();
+	if (!hasIndex(row, column, parent))
+		return QModelIndex();
 
-	std::vector<FrameItem> newRows;
-	for (const DebugFrame& frame : frames)
-	{
-		uint64_t offset = frame.m_pc - frame.m_functionStart;
-		QString funcName = QString::asprintf("%s + 0x%" PRIx64, frame.m_functionName.c_str(), offset);
+	FrameItem* parentItem;
 
-		newRows.emplace_back((int)frame.m_index, frame.m_module, funcName.toStdString(), frame.m_pc, frame.m_sp, frame.m_fp);
-	}
+	if (!parent.isValid())
+		parentItem = rootItem;
+	else
+		parentItem = static_cast<FrameItem*>(parent.internalPointer());
 
-	m_items = newRows;
-	endResetModel();
+	FrameItem* childItem = parentItem->child(row);
+	if (childItem)
+		return createIndex(row, column, childItem);
+	return QModelIndex();
 }
 
 
-ThreadFramesItemDelegate::ThreadFramesItemDelegate(QWidget* parent) : QStyledItemDelegate(parent)
+QModelIndex ThreadFrameModel::parent(const QModelIndex& index) const
 {
+	if (!index.isValid())
+		return QModelIndex();
+
+	FrameItem* childItem = static_cast<FrameItem*>(index.internalPointer());
+	FrameItem* parentItem = childItem->parentItem();
+
+	if (parentItem == rootItem)
+		return QModelIndex();
+
+	return createIndex(parentItem->row(), 0, parentItem);
+}
+
+
+int ThreadFrameModel::rowCount(const QModelIndex& parent) const
+{
+	FrameItem* parentItem;
+	if (parent.column() > 0)
+		return 0;
+
+	if (!parent.isValid())
+		parentItem = rootItem;
+	else
+		parentItem = static_cast<FrameItem*>(parent.internalPointer());
+
+	return parentItem->childCount();
+}
+
+
+ThreadFramesItemDelegate::ThreadFramesItemDelegate(QWidget* parent, DebuggerController* controller) :
+	QStyledItemDelegate(parent)
+{
+	m_debugger = controller;
 	updateFonts();
 }
 
@@ -211,8 +292,6 @@ ThreadFramesItemDelegate::ThreadFramesItemDelegate(QWidget* parent) : QStyledIte
 void ThreadFramesItemDelegate::paint(
 	QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& idx) const
 {
-	painter->setFont(m_font);
-
 	bool selected = (option.state & QStyle::State_Selected) != 0;
 	if (selected)
 		painter->setBrush(getThemeColor(SelectionColor));
@@ -229,22 +308,47 @@ void ThreadFramesItemDelegate::paint(
 	auto data = idx.data(Qt::DisplayRole);
 	switch (idx.column())
 	{
-	case ThreadFramesListModel::IndexColumn:
-	{
-		painter->setPen(getThemeColor(NumberColor).rgba());
-		painter->drawText(textRect, data.toString());
-		break;
-	}
-	case ThreadFramesListModel::ModuleColumn:
-	case ThreadFramesListModel::FunctionColumn:
+	case ThreadFrameModel::StateColumn:
 	{
 		painter->setPen(option.palette.color(QPalette::WindowText).rgba());
 		painter->drawText(textRect, data.toString());
 		break;
 	}
-	case ThreadFramesListModel::PcColumn:
-	case ThreadFramesListModel::FpColumn:
-	case ThreadFramesListModel::SpColumn:
+	case ThreadFrameModel::ThreadColumn:
+	{
+		// make thread column bold, if this is active thread
+		FrameItem* threadItem = static_cast<FrameItem*>(idx.internalPointer());
+		if (threadItem)
+		{
+			auto currentTid = m_debugger->GetActiveThread().m_tid;
+			if (!threadItem->isFrame() && (currentTid == threadItem->tid()))
+			{
+				QFont font = m_font;
+				font.setBold(true);
+				painter->setFont(font);
+			}
+		}
+
+		painter->setPen(option.palette.color(QPalette::WindowText).rgba());
+		painter->drawText(textRect, data.toString());
+		break;
+	}
+	case ThreadFrameModel::FrameIndexColumn:
+	{
+		painter->setPen(getThemeColor(NumberColor).rgba());
+		painter->drawText(textRect, data.toString());
+		break;
+	}
+	case ThreadFrameModel::ModuleColumn:
+	case ThreadFrameModel::FunctionColumn:
+	{
+		painter->setPen(option.palette.color(QPalette::WindowText).rgba());
+		painter->drawText(textRect, data.toString());
+		break;
+	}
+	case ThreadFrameModel::PcColumn:
+	case ThreadFrameModel::FpColumn:
+	case ThreadFrameModel::SpColumn:
 	{
 		painter->setPen(getThemeColor(AddressColor).rgba());
 		painter->drawText(textRect, data.toString());
@@ -274,6 +378,158 @@ QSize ThreadFramesItemDelegate::sizeHint(const QStyleOptionViewItem& option, con
 	return QSize(totalWidth, m_charHeight + 2);
 }
 
+
+void ThreadFramesWidget::contextMenuEvent(QContextMenuEvent* event)
+{
+	m_contextMenuManager->show(m_menu, &m_actionHandler);
+}
+
+void ThreadFramesWidget::makeItSoloThread()
+{
+	QModelIndexList sel = m_threadFramesTree->selectionModel()->selectedIndexes();
+	if (sel.empty())
+		return;
+
+	FrameItem* item = static_cast<FrameItem*>(sel[0].internalPointer());
+	if (!item)
+		return;
+
+	auto soloTid = item->tid();
+	auto isSoloFrozen = item->isFrozen();
+
+	auto threads = m_debugger->GetThreads();
+	for (const DebugThread& thread : threads)
+	{
+		if (thread.m_tid != soloTid && !thread.m_isFrozen)
+			m_debugger->SuspendThread(thread.m_tid);
+	}
+
+	// make sure solo thread is unfrozen and activated
+	if (isSoloFrozen)
+		m_debugger->ResumeThread(soloTid);
+
+	if (m_debugger->GetActiveThread().m_tid != soloTid)
+		m_debugger->SetActiveThread(soloTid);
+}
+
+void ThreadFramesWidget::resumeThread()
+{
+	QModelIndexList sel = m_threadFramesTree->selectionModel()->selectedIndexes();
+	if (sel.empty())
+		return;
+
+	FrameItem* item = static_cast<FrameItem*>(sel[0].internalPointer());
+	if (!item)
+		return;
+
+	// resume & suspend only works at thread rows
+	if (item->isFrame())
+		return;
+
+	m_debugger->ResumeThread(item->tid());
+}
+
+
+void ThreadFramesWidget::suspendThread()
+{
+	QModelIndexList sel = m_threadFramesTree->selectionModel()->selectedIndexes();
+	if (sel.empty())
+		return;
+
+	FrameItem* item = static_cast<FrameItem*>(sel[0].internalPointer());
+	if (!item)
+		return;
+
+	if (item->isFrame())
+		return;
+
+	m_debugger->SuspendThread(item->tid());
+}
+
+
+bool ThreadFramesWidget::selectionNotEmpty()
+{
+	QModelIndexList sel = m_threadFramesTree->selectionModel()->selectedIndexes();
+	return (!sel.empty()) && sel[0].isValid();
+}
+
+
+bool ThreadFramesWidget::canSuspendOrResume()
+{
+	if (!m_debugger->IsConnected() || m_debugger->IsRunning())
+		return false;
+
+	QModelIndexList sel = m_threadFramesTree->selectionModel()->selectedIndexes();
+	if (sel.empty() || !sel[0].isValid())
+		return false;
+
+	FrameItem* item = static_cast<FrameItem*>(sel[0].internalPointer());
+	if (!item)
+		return false;
+
+	if (item->isFrame())
+		return false;
+
+	return true;
+}
+
+
+void ThreadFramesWidget::copy()
+{
+	QModelIndexList sel = m_threadFramesTree->selectionModel()->selectedIndexes();
+	if (sel.empty() || !sel[0].isValid())
+		return;
+
+	FrameItem* item = static_cast<FrameItem*>(sel[0].internalPointer());
+	if (!item)
+		return;
+
+	QString text;
+
+	switch (sel[0].column())
+	{
+	case ThreadFrameModel::StateColumn:
+		if (item->isFrame())
+			return;
+
+		text = item->isFrozen() ? "Frozen" : "Unfrozen";
+		break;
+	case ThreadFrameModel::ThreadColumn:
+		if (item->isFrame())
+			return;
+
+		text = QString::asprintf("0x%x @ 0x%" PRIx64, item->tid(), item->threadPc());
+		break;
+	case ThreadFrameModel::FrameIndexColumn:
+		text = QString::asprintf("%lu", item->frameIndex());
+		break;
+	case ThreadFrameModel::ModuleColumn:
+		text = QString::fromStdString(item->module());
+		break;
+	case ThreadFrameModel::FunctionColumn:
+		text = QString::fromStdString(item->function());
+		break;
+	case ThreadFrameModel::PcColumn:
+		text = QString::asprintf("0x%" PRIx64, item->framePc());
+		break;
+	case ThreadFrameModel::SpColumn:
+		text = QString::asprintf("0x%" PRIx64, item->sp());
+		break;
+	case ThreadFrameModel::FpColumn:
+		text = QString::asprintf("0x%" PRIx64, item->fp());
+		break;
+	default:
+		break;
+	}
+
+	auto* clipboard = QGuiApplication::clipboard();
+	clipboard->clear();
+	auto* mime = new QMimeData();
+	mime->setText(text);
+	clipboard->setMimeData(mime);
+}
+
+
 ThreadFramesWidget::ThreadFramesWidget(QWidget* parent, ViewFrame* frame, BinaryViewRef data) :
 	QWidget(parent), m_view(frame)
 {
@@ -286,44 +542,79 @@ ThreadFramesWidget::ThreadFramesWidget(QWidget* parent, ViewFrame* frame, Binary
 	layout->setSpacing(0);
 	setFont(getMonospaceFont(this));
 
-	m_threadList = new QComboBox(this);
+	m_threadFramesTree = new QTreeView(this);
+	m_threadFramesTree->setExpandsOnDoubleClick(false);
+	m_threadFramesTree->setSelectionBehavior(QAbstractItemView::SelectItems);
+	m_threadFramesTree->setHorizontalScrollMode(QAbstractItemView::ScrollPerPixel);
+	m_threadFramesTree->setVerticalScrollMode(QAbstractItemView::ScrollPerPixel);
+	m_threadFramesTree->header()->setSectionResizeMode(QHeaderView::ResizeToContents);
 
-	m_threadFramesTable = new QTableView(this);
-	m_model = new ThreadFramesListModel(m_threadFramesTable, frame);
+	m_model = new ThreadFrameModel(m_threadFramesTree, m_debugger);
+	m_threadFramesTree->setModel(m_model);
 
-	m_threadFramesTable->setModel(m_model);
-	m_threadFramesTable->setShowGrid(false);
+	m_delegate = new ThreadFramesItemDelegate(this, m_debugger);
+	m_threadFramesTree->setItemDelegate(m_delegate);
 
-	m_delegate = new ThreadFramesItemDelegate(this);
-	m_threadFramesTable->setItemDelegate(m_delegate);
-
-	m_threadFramesTable->setSelectionBehavior(QAbstractItemView::SelectItems);
-
-	m_threadFramesTable->verticalHeader()->setSectionResizeMode(QHeaderView::ResizeToContents);
-	m_threadFramesTable->verticalHeader()->setVisible(false);
-
-	m_threadFramesTable->setHorizontalScrollMode(QAbstractItemView::ScrollPerPixel);
-	m_threadFramesTable->setVerticalScrollMode(QAbstractItemView::ScrollPerPixel);
-
-	m_threadFramesTable->resizeColumnsToContents();
-	m_threadFramesTable->resizeRowsToContents();
-
-	layout->addWidget(new QLabel("Thread:"));
-	layout->addWidget(m_threadList);
-	layout->addWidget(m_threadFramesTable);
+	layout->addWidget(m_threadFramesTree);
 	setLayout(layout);
 
 	// Set up colors
 	QPalette widgetPalette = this->palette();
 
-	connect(m_threadFramesTable, &QTableView::doubleClicked, this, &ThreadFramesWidget::onDoubleClicked);
+	m_actionHandler.setupActionHandler(this);
+	m_contextMenuManager = new ContextMenuManager(this);
+	m_menu = new Menu();
 
-	connect(m_threadList, &QComboBox::activated, [&](int index) {
-		uint32_t tid = m_threadList->currentData().toInt();
-		uint32_t currentTid = m_debugger->GetActiveThread().m_tid;
-		if (tid != currentTid)
-			m_debugger->SetActiveThread(tid);
+	QString actionName = QString::fromStdString("Suspend");
+	UIAction::registerAction(actionName);
+	m_menu->addAction(actionName, "Options", MENU_ORDER_FIRST);
+	m_actionHandler.bindAction(
+		actionName, UIAction([=]() { suspendThread(); }, [=]() { return canSuspendOrResume(); }));
+
+	actionName = QString::fromStdString("Resume");
+	UIAction::registerAction(actionName);
+	m_menu->addAction(actionName, "Options", MENU_ORDER_FIRST);
+	m_actionHandler.bindAction(actionName, UIAction([=]() { resumeThread(); }, [=]() { return canSuspendOrResume(); }));
+
+	actionName = QString::fromStdString("Make It Solo Thread");
+	UIAction::registerAction(actionName);
+	m_menu->addAction(actionName, "Options", MENU_ORDER_FIRST);
+	m_actionHandler.bindAction(
+		actionName, UIAction([=]() { makeItSoloThread(); }, [=]() { return canSuspendOrResume(); }));
+
+	m_menu->addAction("Copy", "Options", MENU_ORDER_NORMAL);
+	m_actionHandler.bindAction("Copy", UIAction([&]() { copy(); }, [&]() { return selectionNotEmpty(); }));
+	m_actionHandler.setActionDisplayName("Copy", [&]() {
+		QModelIndexList sel = m_threadFramesTree->selectionModel()->selectedIndexes();
+		if (sel.empty())
+			return "Copy";
+
+		switch (sel[0].column())
+		{
+		case ThreadFrameModel::StateColumn:
+			return "Copy State";
+		case ThreadFrameModel::ThreadColumn:
+			return "Copy Thread";
+		case ThreadFrameModel::FrameIndexColumn:
+			return "Copy Frame Index";
+		case ThreadFrameModel::ModuleColumn:
+			return "Copy Module";
+		case ThreadFrameModel::FunctionColumn:
+			return "Copy Function";
+		case ThreadFrameModel::PcColumn:
+			return "Copy PC";
+		case ThreadFrameModel::SpColumn:
+			return "Copy SP";
+		case ThreadFrameModel::FpColumn:
+			return "Copy FP";
+		default:
+			return "Copy";
+		}
 	});
+
+	// TODO: set as active thread action?
+
+	connect(m_threadFramesTree, &QTreeView::doubleClicked, this, &ThreadFramesWidget::onDoubleClicked);
 
 	m_debuggerEventCallback = m_debugger->RegisterEventCallback(
 		[&](const DebuggerEvent& event) {
@@ -332,6 +623,7 @@ ThreadFramesWidget::ThreadFramesWidget(QWidget* parent, ViewFrame* frame, Binary
 			case TargetStoppedEventType:
 			case ActiveThreadChangedEvent:
 			case RegisterChangedEvent:
+			case ThreadStateChangedEvent:
 			{
 				updateContent();
 			}
@@ -352,53 +644,93 @@ ThreadFramesWidget::~ThreadFramesWidget()
 }
 
 
+void ThreadFramesWidget::expandCurrentThread()
+{
+	for (int i = 0; i < m_model->rowCount(); i++)
+	{
+		auto index = m_model->index(i, 0);
+		if (!index.isValid())
+			return;
+
+		FrameItem* item = static_cast<FrameItem*>(index.internalPointer());
+		if (!item)
+			return;
+
+		if (m_debugger->GetActiveThread().m_tid == item->tid())
+		{
+			m_threadFramesTree->expand(index);
+			return;
+		}
+	}
+}
+
+
 void ThreadFramesWidget::updateContent()
 {
-	std::vector<DebugThread> threads = m_debugger->GetThreads();
-	m_threadList->clear();
-	for (const DebugThread thread : threads)
-	{
-		m_threadList->addItem(
-			QString::asprintf("0x%" PRIx64 " @ 0x%" PRIx64, (uint64_t)thread.m_tid, (uint64_t)thread.m_rip),
-			QVariant(thread.m_tid));
-	}
-
-	DebugThread activeThread = m_debugger->GetActiveThread();
-	int index = m_threadList->findData(QVariant(activeThread.m_tid));
-	if (index == -1)
+	if (!m_debugger->IsConnected())
 		return;
 
-	m_threadList->setCurrentIndex(index);
-
-	std::vector<DebugFrame> frames = m_debugger->GetFramesOfThread(activeThread.m_tid);
-	m_model->updateRows(frames);
-	m_threadFramesTable->resizeColumnsToContents();
+	m_model->updateRows(m_debugger);
+	expandCurrentThread();
 }
 
 
 void ThreadFramesWidget::onDoubleClicked()
 {
-	QModelIndexList sel = m_threadFramesTable->selectionModel()->selectedIndexes();
+	QModelIndexList sel = m_threadFramesTree->selectionModel()->selectedIndexes();
 	if (sel.empty())
 		return;
 
-	if (sel[0].column() < ThreadFramesListModel::FunctionColumn)
+	auto column = sel[0].column();
+
+	if (column == ThreadFrameModel::FrameIndexColumn || column == ThreadFrameModel::ModuleColumn)
 		return;
 
-	auto frameItem = m_model->getRow(sel[0].row());
+	FrameItem* frameItem = static_cast<FrameItem*>(sel[0].internalPointer());
+	if (!frameItem)
+		return;
+
+	if (!frameItem->isFrame() && column > ThreadFrameModel::ThreadColumn)
+		return;
+
+	if (frameItem->isFrame() && column <= ThreadFrameModel::ThreadColumn)
+		return;
+
+	// Double clicking on thread column changes active thread
+	if (!frameItem->isFrame() && column == ThreadFrameModel::ThreadColumn)
+	{
+		uint32_t tid = frameItem->tid();
+		uint32_t currentTid = m_debugger->GetActiveThread().m_tid;
+		
+		if (tid != currentTid && !m_debugger->IsRunning())
+			m_debugger->SetActiveThread(tid);
+
+		return;
+	}
+
+	// double clicking on state column toggles thread state
+	if (!frameItem->isFrame() && column == ThreadFrameModel::StateColumn)
+	{
+		if (frameItem->isFrozen())
+			m_debugger->ResumeThread(frameItem->tid());
+		else
+			m_debugger->SuspendThread(frameItem->tid());
+
+		return;
+	}
 
 	uint64_t addrToJump = 0;
-	switch (sel[0].column())
+	switch (column)
 	{
-	case ThreadFramesListModel::FunctionColumn:
-	case ThreadFramesListModel::PcColumn:
-		addrToJump = frameItem.pc();
+	case ThreadFrameModel::FunctionColumn:
+	case ThreadFrameModel::PcColumn:
+		addrToJump = frameItem->framePc();
 		break;
-	case ThreadFramesListModel::SpColumn:
-		addrToJump = frameItem.sp();
+	case ThreadFrameModel::SpColumn:
+		addrToJump = frameItem->sp();
 		break;
-	case ThreadFramesListModel::FpColumn:
-		addrToJump = frameItem.fp();
+	case ThreadFrameModel::FpColumn:
+		addrToJump = frameItem->fp();
 		break;
 	}
 

--- a/ui/threadframes.h
+++ b/ui/threadframes.h
@@ -16,19 +16,21 @@ limitations under the License.
 
 #pragma once
 
-#include <QtWidgets/QTableView>
-#include <QtWidgets/QComboBox>
+#include <QtWidgets/QTreeView>
 #include <QStyledItemDelegate>
 #include <QAbstractItemModel>
-#include <QItemSelectionModel>
-#include <QModelIndex>
 #include <QHeaderView>
+#include <QGuiApplication>
+#include <QMimeData>
+#include <QClipboard>
 #include "binaryninjaapi.h"
-#include "dockhandler.h"
 #include "globalarea.h"
 #include "viewframe.h"
 #include "fontsettings.h"
 #include "debuggerapi.h"
+#include "inttypes.h"
+#include "ui.h"
+
 
 using namespace BinaryNinjaDebuggerAPI;
 using namespace BinaryNinja;
@@ -36,43 +38,71 @@ using namespace std;
 
 class FrameItem
 {
-private:
-	int m_frameIndex;
-	std::string m_module;
-	std::string m_function;
-	uint64_t m_pc;
-	uint64_t m_sp;
-	uint64_t m_fp;
-
 public:
-	FrameItem(int index, std::string module, std::string function, uint64_t pc, uint64_t sp, uint64_t fp);
-	uint64_t pc() const { return m_pc; }
+	FrameItem() = default;
+
+	FrameItem(const DebugThread& thread, FrameItem* parentItem = nullptr) :
+		m_tid(thread.m_tid), m_threadPc(thread.m_rip), m_isFrozen(thread.m_isFrozen), m_parentItem(parentItem)
+	{}
+
+	FrameItem(const DebugThread& thread, const DebugFrame& frame, FrameItem* parentItem = nullptr) :
+		m_tid(thread.m_tid), m_threadPc(thread.m_rip), m_frameIndex(frame.m_index), m_module(frame.m_module),
+		m_framePc(frame.m_pc), m_sp(frame.m_sp), m_fp(frame.m_fp), m_isFrame(true), m_parentItem(parentItem)
+	{
+		uint64_t offset = frame.m_pc - frame.m_functionStart;
+		QString funcName = QString::asprintf("%s + 0x%" PRIx64, frame.m_functionName.c_str(), offset);
+
+		m_function = funcName.toStdString();
+	}
+
+	~FrameItem();
+
+	void appendChild(FrameItem* child);
+
+	FrameItem* child(int row);
+	int childCount() const;
+	int row() const;
+	FrameItem* parentItem();
+
+	bool isFrame() const { return m_isFrame; }
+	bool isFrozen() const { return m_isFrozen; }
+	uint32_t tid() const { return m_tid; }
+	uint64_t threadPc() const { return m_threadPc; }
+	uint64_t framePc() const { return m_framePc; }
 	uint64_t sp() const { return m_sp; }
 	uint64_t fp() const { return m_fp; }
-	int frameIndex() const { return m_frameIndex; }
+	size_t frameIndex() const { return m_frameIndex; }
 	std::string module() const { return m_module; }
 	std::string function() const { return m_function; }
-	bool operator==(const FrameItem& other) const;
-	bool operator!=(const FrameItem& other) const;
-	bool operator<(const FrameItem& other) const;
+
+private:
+	bool m_isFrame {false};
+	bool m_isFrozen {false};
+	uint32_t m_tid {};
+	uint64_t m_threadPc {};
+	size_t m_frameIndex {};
+	std::string m_module {};
+	std::string m_function {};
+	uint64_t m_framePc {};
+	uint64_t m_sp {};
+	uint64_t m_fp {};
+
+	QList<FrameItem*> m_childItems;
+	FrameItem* m_parentItem;
 };
 
 Q_DECLARE_METATYPE(FrameItem);
 
-
-class ThreadFramesListModel : public QAbstractTableModel
+class ThreadFrameModel : public QAbstractItemModel
 {
 	Q_OBJECT
-
-protected:
-	QWidget* m_owner;
-	ViewFrame* m_view;
-	std::vector<FrameItem> m_items;
 
 public:
 	enum ColumnHeaders
 	{
-		IndexColumn,
+		StateColumn,
+		ThreadColumn,
+		FrameIndexColumn,
 		ModuleColumn,
 		FunctionColumn,
 		PcColumn,
@@ -80,25 +110,24 @@ public:
 		FpColumn,
 	};
 
-	ThreadFramesListModel(QWidget* parent, ViewFrame* view);
-	virtual ~ThreadFramesListModel();
+	explicit ThreadFrameModel(QObject* parent = nullptr, DebuggerControllerRef controller = nullptr);
+	~ThreadFrameModel();
 
-	virtual QModelIndex index(int row, int col, const QModelIndex& parent = QModelIndex()) const override;
-
-	virtual int rowCount(const QModelIndex& parent = QModelIndex()) const override
+	QVariant data(const QModelIndex& index, int role) const override;
+	QVariant headerData(int column, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
+	QModelIndex index(int row, int column, const QModelIndex& parent = QModelIndex()) const override;
+	QModelIndex parent(const QModelIndex& index) const override;
+	int rowCount(const QModelIndex& parent = QModelIndex()) const override;
+	int columnCount(const QModelIndex& parent = QModelIndex()) const override
 	{
 		(void)parent;
-		return (int)m_items.size();
+		return 8;
 	}
-	virtual int columnCount(const QModelIndex& parent = QModelIndex()) const override
-	{
-		(void)parent;
-		return 6;
-	}
-	FrameItem getRow(int row) const;
-	virtual QVariant data(const QModelIndex& i, int role) const override;
-	virtual QVariant headerData(int column, Qt::Orientation orientation, int role) const override;
-	void updateRows(std::vector<DebugFrame> frames);
+	void updateRows(DebuggerController* controller);
+
+private:
+	FrameItem* rootItem;
+	DebuggerControllerRef m_controller = nullptr;
 };
 
 
@@ -108,9 +137,10 @@ class ThreadFramesItemDelegate : public QStyledItemDelegate
 
 	QFont m_font;
 	int m_baseline, m_charWidth, m_charHeight, m_charOffset;
+	DbgRef<DebuggerController> m_debugger;
 
 public:
-	ThreadFramesItemDelegate(QWidget* parent);
+	ThreadFramesItemDelegate(QWidget* parent, DebuggerController* controller);
 	void updateFonts();
 	void paint(QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& idx) const;
 	QSize sizeHint(const QStyleOptionViewItem& option, const QModelIndex& idx) const;
@@ -123,13 +153,22 @@ class ThreadFramesWidget : public QWidget
 	ViewFrame* m_view;
 	DbgRef<DebuggerController> m_debugger;
 
-	QComboBox* m_threadList;
-	QTableView* m_threadFramesTable;
-	ThreadFramesListModel* m_model;
+	QTreeView* m_threadFramesTree;
+	ThreadFrameModel* m_model;
 	ThreadFramesItemDelegate* m_delegate;
+
+	UIActionHandler m_actionHandler;
+	ContextMenuManager* m_contextMenuManager;
+	Menu* m_menu;
 
 	size_t m_debuggerEventCallback;
 
+	virtual void contextMenuEvent(QContextMenuEvent* event) override;
+	bool selectionNotEmpty();
+	bool canSuspendOrResume();
+	void expandCurrentThread();
+
+public slots:
 	void updateContent();
 
 public:
@@ -140,6 +179,10 @@ public:
 
 private slots:
 	void onDoubleClicked();
+	void suspendThread();
+	void resumeThread();
+	void makeItSoloThread();
+	void copy();
 };
 
 class GlobalThreadFramesContainer : public GlobalAreaWidget


### PR DESCRIPTION
fixes #373, #374

This PR adds support for thread suspend /resume for both LLDB and dbgeng backends. It also makes stack trace view a treeview in order to show both threads and their frames.

NOTE: I did not remove some log output to make it easier to understand that the code is working correctly. I guess we should remove them before merging.

Preview:

![preview](https://user-images.githubusercontent.com/109607896/207034202-415acc61-f45b-446b-8f08-ad91afbff860.png)
