### PR TITLE
Create a debugger controller per file metadata rather than per binary view

### DIFF
--- a/core/debuggercontroller.h
+++ b/core/debuggercontroller.h
@@ -61,7 +61,8 @@ namespace BinaryNinjaDebugger {
 	private:
 		DebugAdapter* m_adapter;
 		DebuggerState* m_state;
-		BinaryViewRef m_data;
+		FileMetadataRef m_file;
+		std::string m_viewName;
 		BinaryViewRef m_liveView;
 
 //		inline static std::vector<DbgRef<DebuggerController>> g_debuggerControllers;
@@ -250,8 +251,8 @@ namespace BinaryNinjaDebugger {
 		// getters
 		DebugAdapter* GetAdapter() { return m_adapter; }
 		DebuggerState* GetState() { return m_state; }
-		BinaryViewRef GetData() const { return m_data; }
-		void SetData(BinaryViewRef view) { m_data = view; }
+		BinaryViewRef GetData() { return m_file->GetViewOfType(m_viewName); }
+		void SetData(BinaryViewRef view) {}
 		BinaryViewRef GetLiveView() const { return m_liveView; }
 
 		uint32_t GetExitCode();

--- a/ui/ui.cpp
+++ b/ui/ui.cpp
@@ -1185,7 +1185,6 @@ void DebuggerUI::updateUI(const DebuggerEvent& event)
 		}
 
 		Ref<BinaryView> rebasedView = fileMetadata->GetViewOfType(data->GetTypeName());
-		m_controller->SetData(rebasedView);
 
 		bool result = false;
 		QString text = QString("Adding the input view into the debugger view...");


### PR DESCRIPTION
This PR attempts to fix https://github.com/Vector35/binaryninja/issues. It creates a debugger controller for each file metadata rather than each binary view, and ensures the debugger core does not take any references on the binary view