### PR TITLE
Update dbgengadapter.cpp

### DIFF
--- a/core/adapters/dbgengadapter.cpp
+++ b/core/adapters/dbgengadapter.cpp
@@ -1000,6 +1000,7 @@ bool DbgEngAdapter::RemoveBreakpoint(const ModuleNameAndOffset& breakpoint)
 		if (it != m_pendingBreakpoints.end())
 			m_pendingBreakpoints.erase(it);
 	}
+	return true;
 }
 
 std::vector<DebugBreakpoint> DbgEngAdapter::GetBreakpointList() const


### PR DESCRIPTION
Fix `BinaryNinjaDebugger::DbgEngAdapter::RemoveBreakpoint` to always return a value