### PR TITLE
Add active_pid property to get debugged process ID

### DIFF
--- a/api/debuggerapi.h
+++ b/api/debuggerapi.h
@@ -628,6 +628,8 @@ namespace BinaryNinjaDebuggerAPI {
 
 		std::vector<DebugProcess> GetProcessList();
 
+		std::uint32_t GetActivePID();
+
 		std::vector<DebugThread> GetThreads();
 		DebugThread GetActiveThread();
 		void SetActiveThread(const DebugThread& thread);

--- a/api/debuggercontroller.cpp
+++ b/api/debuggercontroller.cpp
@@ -164,6 +164,12 @@ std::vector<DebugProcess> DebuggerController::GetProcessList()
 }
 
 
+std::uint32_t DebuggerController::GetActivePID()
+{
+	return BNDebuggerGetActivePID(m_object);
+}
+
+
 std::vector<DebugThread> DebuggerController::GetThreads()
 {
 	size_t count;

--- a/api/ffi.h
+++ b/api/ffi.h
@@ -474,6 +474,8 @@ extern "C"
 	DEBUGGER_FFI_API BNDebugProcess* BNDebuggerGetProcessList(BNDebuggerController* controller, size_t* count);
 	DEBUGGER_FFI_API void BNDebuggerFreeProcessList(BNDebugProcess* processes, size_t count);
 
+	DEBUGGER_FFI_API uint32_t BNDebuggerGetActivePID(BNDebuggerController* controller);
+
 	DEBUGGER_FFI_API BNDebugThread* BNDebuggerGetThreads(BNDebuggerController* controller, size_t* count);
 	DEBUGGER_FFI_API void BNDebuggerFreeThreads(BNDebugThread* threads, size_t count);
 

--- a/api/python/debuggercontroller.py
+++ b/api/python/debuggercontroller.py
@@ -1795,6 +1795,17 @@ class DebuggerController:
         dbgcore.BNDebuggerSetPIDAttach(self.handle, pid)
 
     @property
+    def active_pid(self) -> int:
+        """
+        The PID of the process currently being debugged. (read-only)
+
+        This returns the PID of the currently attached or running process.
+
+        :return: the PID of the active process, or 0 if no process is active or the PID is unavailable
+        """
+        return dbgcore.BNDebuggerGetActivePID(self.handle)
+
+    @property
     def executable_path(self) -> str:
         """
         The path of the executable. (read/write)

--- a/core/adapters/corelliumadapter.cpp
+++ b/core/adapters/corelliumadapter.cpp
@@ -227,6 +227,7 @@ bool CorelliumAdapter::Connect(const std::string& server, std::uint32_t port)
     const auto reply = this->m_rspConnector->TransmitAndReceive(RspData("?"));
     auto map = RspConnector::PacketToUnorderedMap(reply);
 	this->m_lastActiveThreadId = map["thread"];
+	this->m_processPid = map["thread"];
     m_isTargetRunning = false;
 
 	Ref<Settings> settings = Settings::Instance();
@@ -1027,6 +1028,12 @@ void CorelliumAdapter::HandleAsyncPacket(const RspData& data)
 std::vector<DebugProcess> CorelliumAdapter::GetProcessList()
 {
 	return {};
+}
+
+
+std::uint32_t CorelliumAdapter::GetActivePID()
+{
+	return m_processPid;
 }
 
 

--- a/core/adapters/corelliumadapter.h
+++ b/core/adapters/corelliumadapter.h
@@ -48,6 +48,7 @@ namespace BinaryNinjaDebugger
 		std::vector<DebugBreakpoint> m_debugBreakpoints{};
 
 		std::uint32_t m_lastActiveThreadId{};
+		std::uint32_t m_processPid{};
 		uint8_t m_exitCode{};
 
 		std::string GetGDBServerPath();
@@ -120,6 +121,7 @@ namespace BinaryNinjaDebugger
 		std::string InvokeBackendCommand(const std::string& command) override;
 		std::string RunMonitorCommand(const std::string& command);
 		uint64_t GetInstructionOffset() override;
+		std::uint32_t GetActivePID() override;
 
 		DebugStopReason ResponseHandler();
 

--- a/core/adapters/dbgengadapter.cpp
+++ b/core/adapters/dbgengadapter.cpp
@@ -1506,6 +1506,20 @@ uint64_t DbgEngAdapter::GetStackPointer()
 	return stackPointer;
 }
 
+
+std::uint32_t DbgEngAdapter::GetActivePID()
+{
+	if (!m_debugSystemObjects)
+		return 0;
+
+	ULONG pid {};
+	if (m_debugSystemObjects->GetCurrentProcessSystemId(&pid) != S_OK)
+		return 0;
+
+	return pid;
+}
+
+
 unsigned long DbgEngEventCallbacks::AddRef()
 {
 	return 1;

--- a/core/adapters/dbgengadapter.h
+++ b/core/adapters/dbgengadapter.h
@@ -228,6 +228,7 @@ namespace BinaryNinjaDebugger {
 		std::string InvokeBackendCommand(const std::string& command) override;
 		uint64_t GetInstructionOffset() override;
 		uint64_t GetStackPointer() override;
+		std::uint32_t GetActivePID() override;
 
 		bool SupportFeature(DebugAdapterCapacity feature) override;
 

--- a/core/adapters/esrevenadapter.cpp
+++ b/core/adapters/esrevenadapter.cpp
@@ -259,6 +259,7 @@ bool EsrevenAdapter::Connect(const std::string& server, std::uint32_t port)
     const auto reply = this->m_rspConnector->TransmitAndReceive(RspData("?"));
     auto map = RspConnector::PacketToUnorderedMap(reply);
 	this->m_lastActiveThreadId = map["thread"];
+	this->m_processPid = map["thread"];
     m_isTargetRunning = false;
 
 	if (Settings::Instance()->Get<bool>("debugger.stopAtEntryPoint") && m_hasEntryFunction)
@@ -1198,6 +1199,13 @@ uint64_t EsrevenAdapter::GetStackPointer()
 	uint64_t value = (uint64_t)this->ReadRegister(ipRegisterName).m_value;
 	return value;
 }
+
+
+std::uint32_t EsrevenAdapter::GetActivePID()
+{
+	return m_processPid;
+}
+
 
 DebugStopReason EsrevenAdapter::StopReason()
 {

--- a/core/adapters/esrevenadapter.h
+++ b/core/adapters/esrevenadapter.h
@@ -61,6 +61,7 @@ namespace BinaryNinjaDebugger
 		std::optional<std::vector<DebugModule>> m_moduleCache{};
 
 		std::uint32_t m_lastActiveThreadId{};
+		std::uint32_t m_processPid{};
 		uint8_t m_exitCode{};
 
 		std::string GetGDBServerPath();
@@ -145,6 +146,7 @@ namespace BinaryNinjaDebugger
 		std::string RunMonitorCommand(const std::string& command);
 		uint64_t GetInstructionOffset() override;
 		uint64_t GetStackPointer() override;
+		std::uint32_t GetActivePID() override;
 
 		DebugStopReason ResponseHandler(bool notifyStopped = true);
 

--- a/core/adapters/gdbadapter.cpp
+++ b/core/adapters/gdbadapter.cpp
@@ -259,6 +259,7 @@ bool GdbAdapter::Connect(const std::string& server, std::uint32_t port)
     const auto reply = this->m_rspConnector->TransmitAndReceive(RspData("?"));
     auto map = RspConnector::PacketToUnorderedMap(reply);
 	this->m_lastActiveThreadId = map["thread"];
+	this->m_processPid = map["thread"];
     m_isTargetRunning = false;
 
 	if (Settings::Instance()->Get<bool>("debugger.stopAtEntryPoint") && m_hasEntryFunction)
@@ -1246,6 +1247,13 @@ uint64_t GdbAdapter::GetStackPointer()
 	uint64_t value = (uint64_t)this->ReadRegister(ipRegisterName).m_value;
 	return value;
 }
+
+
+std::uint32_t GdbAdapter::GetActivePID()
+{
+	return m_processPid;
+}
+
 
 DebugStopReason GdbAdapter::StopReason()
 {

--- a/core/adapters/gdbadapter.h
+++ b/core/adapters/gdbadapter.h
@@ -61,6 +61,7 @@ namespace BinaryNinjaDebugger
 		std::optional<std::vector<DebugModule>> m_moduleCache{};
 
 		std::uint32_t m_lastActiveThreadId{};
+		std::uint32_t m_processPid{};
 		uint8_t m_exitCode{};
 
 		std::string GetGDBServerPath();
@@ -145,6 +146,7 @@ namespace BinaryNinjaDebugger
 		std::string RunMonitorCommand(const std::string& command);
 		uint64_t GetInstructionOffset() override;
 		uint64_t GetStackPointer() override;
+		std::uint32_t GetActivePID() override;
 
 		DebugStopReason ResponseHandler(bool notifyStopped = true);
 

--- a/core/adapters/lldbadapter.cpp
+++ b/core/adapters/lldbadapter.cpp
@@ -752,6 +752,15 @@ std::vector<DebugProcess> LldbAdapter::GetProcessList()
 }
 
 
+std::uint32_t LldbAdapter::GetActivePID()
+{
+	if (!m_process.IsValid())
+		return 0;
+
+	return m_process.GetProcessID();
+}
+
+
 std::vector<DebugThread> LldbAdapter::GetThreadList()
 {
 	size_t threadCount = m_process.GetNumThreads();

--- a/core/adapters/lldbadapter.h
+++ b/core/adapters/lldbadapter.h
@@ -68,6 +68,8 @@ namespace BinaryNinjaDebugger {
 
 		std::vector<DebugProcess> GetProcessList() override;
 
+		std::uint32_t GetActivePID() override;
+
 		std::vector<DebugThread> GetThreadList() override;
 
 		DebugThread GetActiveThread() const override;

--- a/core/adapters/lldbcoredumpadapter.cpp
+++ b/core/adapters/lldbcoredumpadapter.cpp
@@ -1236,3 +1236,12 @@ void LldbCoreDumpAdapter::GenerateDefaultAdapterSettings(BinaryView* data)
 	if (scope != SettingsResourceScope)
 		adapterSettings->Set("common.inputFile", data->GetFile()->GetOriginalFilename(), data, SettingsResourceScope);
 }
+
+
+std::uint32_t LldbCoreDumpAdapter::GetActivePID()
+{
+	if (!m_process.IsValid())
+		return 0;
+
+	return m_process.GetProcessID();
+}

--- a/core/adapters/lldbcoredumpadapter.h
+++ b/core/adapters/lldbcoredumpadapter.h
@@ -117,6 +117,7 @@ namespace BinaryNinjaDebugger {
 		uint64_t GetInstructionOffset() override;
 
 		uint64_t GetStackPointer() override;
+		std::uint32_t GetActivePID() override;
 
 		bool SupportFeature(DebugAdapterCapacity feature) override;
 

--- a/core/adapters/queuedadapter.cpp
+++ b/core/adapters/queuedadapter.cpp
@@ -568,6 +568,22 @@ uint64_t QueuedAdapter::GetStackPointer()
 }
 
 
+std::uint32_t QueuedAdapter::GetActivePID()
+{
+    std::unique_lock<std::mutex> lock(m_queueMutex);
+
+    std::uint32_t ret;
+    Semaphore sem;
+    m_queue.push([&]{
+        ret = m_adapter->GetActivePID();
+        sem.Release();
+    });
+    lock.unlock();
+    sem.Wait();
+    return ret;
+}
+
+
 bool QueuedAdapter::SupportFeature(DebugAdapterCapacity feature)
 {
     return m_adapter->SupportFeature(feature);

--- a/core/adapters/queuedadapter.cpp
+++ b/core/adapters/queuedadapter.cpp
@@ -568,22 +568,6 @@ uint64_t QueuedAdapter::GetStackPointer()
 }
 
 
-std::uint32_t QueuedAdapter::GetActivePID()
-{
-    std::unique_lock<std::mutex> lock(m_queueMutex);
-
-    std::uint32_t ret;
-    Semaphore sem;
-    m_queue.push([&]{
-        ret = m_adapter->GetActivePID();
-        sem.Release();
-    });
-    lock.unlock();
-    sem.Wait();
-    return ret;
-}
-
-
 bool QueuedAdapter::SupportFeature(DebugAdapterCapacity feature)
 {
     return m_adapter->SupportFeature(feature);

--- a/core/adapters/queuedadapter.h
+++ b/core/adapters/queuedadapter.h
@@ -84,6 +84,7 @@ namespace BinaryNinjaDebugger
 		std::string InvokeBackendCommand(const std::string& command) override;
 		uint64_t GetInstructionOffset() override;
 		uint64_t GetStackPointer() override;
+		std::uint32_t GetActivePID() override;
 
 		bool SupportFeature(DebugAdapterCapacity feature) override;
 

--- a/core/adapters/queuedadapter.h
+++ b/core/adapters/queuedadapter.h
@@ -84,7 +84,6 @@ namespace BinaryNinjaDebugger
 		std::string InvokeBackendCommand(const std::string& command) override;
 		uint64_t GetInstructionOffset() override;
 		uint64_t GetStackPointer() override;
-		std::uint32_t GetActivePID() override;
 
 		bool SupportFeature(DebugAdapterCapacity feature) override;
 

--- a/core/debugadapter.h
+++ b/core/debugadapter.h
@@ -238,6 +238,8 @@ namespace BinaryNinjaDebugger {
 
 		virtual std::vector<DebugProcess> GetProcessList() = 0;
 
+		virtual std::uint32_t GetActivePID() = 0;
+
 		virtual std::vector<DebugThread> GetThreadList() = 0;
 
 		virtual DebugThread GetActiveThread() const = 0;

--- a/core/debuggercontroller.cpp
+++ b/core/debuggercontroller.cpp
@@ -2109,7 +2109,6 @@ uint32_t DebuggerController::GetExitCode()
 
 uint32_t DebuggerController::GetActivePID()
 {
-	std::lock_guard<std::mutex> lock(m_adapterMutex);
 	if (!m_adapter)
 		return 0;
 	return m_adapter->GetActivePID();

--- a/core/debuggercontroller.cpp
+++ b/core/debuggercontroller.cpp
@@ -2107,6 +2107,15 @@ uint32_t DebuggerController::GetExitCode()
 }
 
 
+uint32_t DebuggerController::GetActivePID()
+{
+	std::lock_guard<std::mutex> lock(m_adapterMutex);
+	if (!m_adapter)
+		return 0;
+	return m_adapter->GetActivePID();
+}
+
+
 void DebuggerController::WriteStdIn(const std::string message)
 {
 	if (m_adapter && m_state->IsRunning())

--- a/core/debuggercontroller.h
+++ b/core/debuggercontroller.h
@@ -339,6 +339,7 @@ namespace BinaryNinjaDebugger {
 		DebuggerFileAccessor* GetMemoryAccessor() const { return m_accessor; }
 
 		uint32_t GetExitCode();
+		uint32_t GetActivePID();
 
 		void WriteStdIn(const std::string message);
 

--- a/core/ffi.cpp
+++ b/core/ffi.cpp
@@ -209,6 +209,12 @@ void BNDebuggerFreeProcessList(BNDebugProcess* processes, size_t count)
 }
 
 
+uint32_t BNDebuggerGetActivePID(BNDebuggerController* controller)
+{
+	return controller->object->GetActivePID();
+}
+
+
 BNDebugThread* BNDebuggerGetThreads(BNDebuggerController* controller, size_t* size)
 {
 	std::vector<DebugThread> threads = controller->object->GetAllThreads();


### PR DESCRIPTION
Added `active_pid` property to get the PID of the process that is currently being debugged. Returns 0 if unavailable or nothing is yet attached. 

Implementation is added for every adapter, for GDB it's cached at connection time (as then we know the thread id equals the process pid).