### PR TITLE
Fix debug adapter not available when a different view is created for …

### DIFF
--- a/api/debuggercontroller.cpp
+++ b/api/debuggercontroller.cpp
@@ -69,6 +69,9 @@ DebuggerController::~DebuggerController()
 
 bool DebuggerController::ControllerExists(Ref<BinaryNinja::BinaryView> data)
 {
+	if (!data)
+		return false;
+
 	return BNDebuggerControllerExists(data->GetObject());
 }
 

--- a/core/debuggercontroller.cpp
+++ b/core/debuggercontroller.cpp
@@ -1691,7 +1691,7 @@ void DebuggerController::DeleteController(BinaryViewRef data)
 		if (!controller)
 			continue;
 
-		if (controller->GetData() == data)
+		if (controller->GetFile() == data->GetFile())
 		{
 			g_debuggerControllers[i] = nullptr;
 		}
@@ -1706,7 +1706,7 @@ bool DebuggerController::ControllerExists(BinaryViewRef data)
 		DbgRef<DebuggerController> controller = g_debuggerControllers[i];
 		if (!controller)
 			continue;
-		if (controller->GetData() == data)
+		if (controller->GetFile() == data->GetFile())
 			return true;
 	}
 

--- a/ui/ui.cpp
+++ b/ui/ui.cpp
@@ -812,6 +812,9 @@ void GlobalDebuggerUI::SetupMenu(UIContext* context)
 
 	// Helper function to check if there's a breakpoint at the current address and return its enabled state
 	auto getBreakpointEnabledState = [](BinaryView* view, uint64_t addr) -> std::pair<bool, bool> {
+		if (!DebuggerController::ControllerExists(view))
+			return {false, false};
+
 		auto controller = DebuggerController::GetController(view);
 		if (!controller)
 			return {false, false}; // {hasBreakpoint, isEnabled}


### PR DESCRIPTION
…the file before the current view. Fix https://github.com/Vector35/debugger/issues/908