### PR TITLE
Fix windbg installation when the file name extension is hidden

### DIFF
--- a/ui/install_windbg.cpp
+++ b/ui/install_windbg.cpp
@@ -280,7 +280,20 @@ namespace BinaryNinjaDebugger
 										_bstr_t itemName(bstrName, false); // Don't copy, take ownership
 										LogInfo("Found item in ZIP archive: %s", (const char*)itemName);
 
-										if (_stricmp(itemName, fileName.c_str()) == 0)
+										// Extract base name without extension for comparison
+										// This handles the case where Windows "Hide extensions for known file types" is enabled
+										std::string fileNameWithoutExt = fileName;
+										size_t lastDot = fileNameWithoutExt.find_last_of('.');
+										if (lastDot != std::string::npos)
+										{
+											fileNameWithoutExt = fileNameWithoutExt.substr(0, lastDot);
+										}
+
+										// Match either the full filename or the filename without extension
+										bool matches = (_stricmp(itemName, fileName.c_str()) == 0) ||
+										               (_stricmp(itemName, fileNameWithoutExt.c_str()) == 0);
+
+										if (matches)
 										{
 											// Found the file, extract it
 											VARIANT vOptions;

--- a/ui/install_windbg.cpp
+++ b/ui/install_windbg.cpp
@@ -156,7 +156,7 @@ namespace BinaryNinjaDebugger
 							}
 							else
 							{
-								LogError("Shell CopyHere failed: 0x%08x", hr);
+								LogError("Shell CopyHere failed: 0x%08x. If you see 'file in use' errors, please close Binary Ninja and try again.", hr);
 							}
 
 							pItems->Release();
@@ -278,7 +278,8 @@ namespace BinaryNinjaDebugger
 									if (SUCCEEDED(hr) && bstrName)
 									{
 										_bstr_t itemName(bstrName, false); // Don't copy, take ownership
-										
+										LogInfo("Found item in ZIP archive: %s", (const char*)itemName);
+
 										if (_stricmp(itemName, fileName.c_str()) == 0)
 										{
 											// Found the file, extract it
@@ -308,7 +309,7 @@ namespace BinaryNinjaDebugger
 
 							if (outputPath.empty())
 							{
-								LogError("File %s not found in ZIP archive", fileName.c_str());
+								LogError("File %s not found in ZIP archive. This may indicate that Microsoft has changed the WinDbg package structure. Please report this issue to the Binary Ninja team.", fileName.c_str());
 							}
 
 							pItems->Release();

--- a/ui/ui.cpp
+++ b/ui/ui.cpp
@@ -1309,6 +1309,28 @@ void GlobalDebuggerUI::SetupMenu(UIContext* context)
 #ifdef WIN32
 void GlobalDebuggerUI::installTTD(const UIActionContext& ctxt)
 {
+	// Check if WinDbg is already installed
+	std::string userDir = BinaryNinja::GetUserDirectory();
+	std::filesystem::path installTarget = std::filesystem::path(userDir) / "windbg";
+	LogDebug("installTarget: %s", installTarget.string().c_str());
+
+	if (std::filesystem::exists(installTarget) && BinaryNinjaDebugger::CheckInstallOk(installTarget.string()))
+	{
+		QMessageBox::StandardButton reply = QMessageBox::information(
+			ctxt.context->mainWindow(),
+			"WinDbg Already Installed",
+			"WinDbg/TTD is already installed. Do you want to reinstall/update it?\n\n"
+			"IMPORTANT: Reinstallation will fail if Binary Ninja is currently running because the DbgEng DLLs are in use.\n\n"
+			"To reinstall/update:\n"
+			"1. Close Binary Ninja completely\n"
+			"2. Manually delete the folder: " + QString::fromStdString(installTarget.string()) + "\n"
+			"3. Restart Binary Ninja\n"
+			"4. Run this installation again\n\n",
+			QMessageBox::Ok
+		);
+		return;
+	}
+
 	// Create and show progress dialog with actual progress range
 	QProgressDialog* progress = new QProgressDialog("Initializing installation...", nullptr, 0, 100, ctxt.context->mainWindow());
 	progress->setWindowModality(Qt::WindowModal);


### PR DESCRIPTION
Not the code handles both "windbg_win-x64" and "windbg_win-x64.msix". Also added some troubleshooting to help diagnose similar cases

This fix and the COM Shell zip extraction is admittedly awkward. I will make a proper ship maybe using https://github.com/zlib-ng/minizip-ng to extract the zip archive after the stable release