### PR TITLE
Add module-relative address resolution for breakpoints

### DIFF
--- a/api/debuggerapi.h
+++ b/api/debuggerapi.h
@@ -638,6 +638,7 @@ namespace BinaryNinjaDebuggerAPI {
 		bool ResumeThread(std::uint32_t tid);
 
 		std::vector<DebugModule> GetModules();
+		bool ParseModuleRelativeAddress(const std::string& input, uint64_t& result);
 		std::vector<DebugRegister> GetRegisters();
 		intx::uint512 GetRegisterValue(const std::string& name);
 		bool SetRegisterValue(const std::string& name, const intx::uint512& value);

--- a/api/debuggercontroller.cpp
+++ b/api/debuggercontroller.cpp
@@ -274,6 +274,50 @@ std::vector<DebugModule> DebuggerController::GetModules()
 }
 
 
+bool DebuggerController::ParseModuleRelativeAddress(const std::string& input, uint64_t& result)
+{
+	const size_t plusPos = input.rfind('+');
+	if (plusPos == std::string::npos || plusPos == 0)
+		return false;
+
+	const size_t moduleEnd = input.find_last_not_of(" \t", plusPos - 1);
+
+	if (moduleEnd == std::string::npos)
+		return false;
+
+	const std::string moduleName = input.substr(0, moduleEnd + 1);
+
+	const size_t offsetStart = input.find_first_not_of(" \t", plusPos + 1);
+	if (offsetStart == std::string::npos)
+		return false;
+	std::string offsetStr = input.substr(offsetStart);
+
+	if (offsetStr.size() >= 2 && offsetStr[0] == '0' && (offsetStr[1] == 'x' || offsetStr[1] == 'X'))
+		offsetStr = offsetStr.substr(2);
+
+	uint64_t offset;
+	try
+	{
+		offset = std::stoull(offsetStr, nullptr, 16);
+	}
+	catch (...)
+	{
+		return false;
+	}
+
+	for (const auto& module : GetModules())
+	{
+		if (DebugModule::IsSameBaseModule(module.m_name, moduleName))
+		{
+			result = module.m_address + offset;
+			return true;
+		}
+	}
+
+	return false;
+}
+
+
 std::vector<DebugRegister> DebuggerController::GetRegisters()
 {
 	size_t count;

--- a/core/debuggercontroller.cpp
+++ b/core/debuggercontroller.cpp
@@ -1823,6 +1823,7 @@ void DebuggerController::EventHandler(const DebuggerEvent& event)
 		DetectLoadedModule();
 		UpdateStackVariables();
 		AddRegisterValuesToExpressionParser();
+		AddModuleValuesToExpressionParser();
 		break;
 	}
 	case ActiveThreadChangedEvent:
@@ -2375,6 +2376,25 @@ void DebuggerController::AddRegisterValuesToExpressionParser()
 	{
 		names.push_back(std::string(reg.m_name));
 		values.emplace_back(reg.m_value);
+	}
+
+	GetData()->AddExpressionParserMagicValues(names, values);
+}
+
+
+void DebuggerController::AddModuleValuesToExpressionParser()
+{
+	auto modules = GetAllModules();
+	std::vector<std::string> names;
+	std::vector<uint64_t> values;
+
+	for (const auto& module : modules)
+	{
+		if (!module.m_short_name.empty())
+		{
+			names.push_back(module.m_short_name);
+			values.push_back(module.m_address);
+		}
 	}
 
 	GetData()->AddExpressionParserMagicValues(names, values);

--- a/core/debuggercontroller.h
+++ b/core/debuggercontroller.h
@@ -130,6 +130,7 @@ namespace BinaryNinjaDebugger {
 		void EventHandler(const DebuggerEvent& event);
 		void UpdateStackVariables();
 		void AddRegisterValuesToExpressionParser();
+		void AddModuleValuesToExpressionParser();
 		bool CreateDebuggerBinaryView();
 
 		DebugStopReason StepIntoIL(BNFunctionGraphType il);

--- a/ui/breakpointswidget.cpp
+++ b/ui/breakpointswidget.cpp
@@ -21,6 +21,8 @@ limitations under the License.
 #include <QGuiApplication>
 #include <QKeyEvent>
 #include <QStringList>
+#include <QInputDialog>
+#include <QMessageBox>
 #include <algorithm>
 #include <QMouseEvent>
 #include "breakpointswidget.h"
@@ -438,15 +440,34 @@ void DebugBreakpointsWidget::add()
 	if (!view)
 		return;
 
-	uint64_t address = 0;
-	if (!ViewFrame::getAddressFromInput(frame, view, address,
-			frame->getCurrentOffset(), "Add Breakpoint", "The address of the breakpoint:", true))
+	auto controller = DebuggerController::GetController(view);
+
+	bool ok;
+	const QString input = QInputDialog::getText(this, "Add Breakpoint",
+		"Address (e.g., 0x1234 or module.exe + 0x1234):", QLineEdit::Normal, "", &ok);
+	if (!ok || input.trimmed().isEmpty())
 		return;
 
-	bool isAbsoluteAddress = false;
-	auto controller = DebuggerController::GetController(view);
+	uint64_t address = 0;
+	bool parsed = false;
+
 	if (controller->IsConnected())
-		isAbsoluteAddress = true;
+	{
+		parsed = controller->ParseModuleRelativeAddress(input.trimmed().toStdString(), address);
+	}
+
+	if (!parsed)
+	{
+		std::string errorString;
+		if (!ViewFrame::getAddressFromString(frame, view, address,
+				frame->getCurrentOffset(), input, errorString))
+		{
+			QMessageBox::warning(this, "Invalid Address", QString::fromStdString(errorString));
+			return;
+		}
+	}
+
+	const bool isAbsoluteAddress = controller->IsConnected();
 
 	if (isAbsoluteAddress)
 	{


### PR DESCRIPTION
The breakpoint addresses copied from the table (e.g., `module + 0x1234`) can now be pasted and used directly in the add breakpoint dialog.

The module names are registered in the expression parser when the debugger stops, resolving to their base addresses automatically.

This PR closes #886.