### PR TITLE
Fix many of the warnings that show up when compiling with GCC 15.2

### DIFF
--- a/core/adapters/corelliumadapter.cpp
+++ b/core/adapters/corelliumadapter.cpp
@@ -521,29 +521,29 @@ bool CorelliumAdapter::WriteRegister(const std::string& reg, intx::uint512 value
     if (m_isTargetRunning)
         return false;
 
-	if (!this->m_registerInfo.contains(reg))
-		return false;
+    if (!this->m_registerInfo.contains(reg))
+        return false;
 
-	const auto newRegString = uint512ToLittleEndianHex(value, this->m_registerInfo[reg].m_bitSize / 8);
-	const auto reply = this->m_rspConnector->TransmitAndReceive(RspData("P{:02X}={}",
-									   this->m_registerInfo[reg].m_regNum, newRegString));
-	if (reply.m_data[0])
+    const auto newRegString = uint512ToLittleEndianHex(value, this->m_registerInfo[reg].m_bitSize / 8);
+    const auto reply = this->m_rspConnector->TransmitAndReceive(RspData("P{:02X}={}",
+                this->m_registerInfo[reg].m_regNum, newRegString));
+    if (reply.m_data[0])
         return true;
 
     char query{'g'};
     const auto generic_query = this->m_rspConnector->TransmitAndReceive(RspData(&query, sizeof(query)));
     const auto register_offset = this->m_registerInfo[reg].m_offset;
 
-	// TODO: check if this works for aarch64
+    // TODO: check if this works for aarch64
     const auto first_half = generic_query.AsString().substr(0, 2 * (register_offset / 8));
     const auto second_half = generic_query.AsString().substr(2 * ((register_offset + this->m_registerInfo[reg].m_bitSize) / 8) );
-	const auto payload = "G" + first_half + newRegString + second_half;
+    const auto payload = "G" + first_half + newRegString + second_half;
 
     if ( this->m_rspConnector->TransmitAndReceive(RspData(payload)).AsString() != "OK" )
         return false;
 
-	// TODO: we do not need to invalidate all register caches, we could probably just update the necessary ones here
-	InvalidateCache();
+    // TODO: we do not need to invalidate all register caches, we could probably just update the necessary ones here
+    InvalidateCache();
     return true;
 }
 
@@ -890,30 +890,30 @@ static std::string HexToAscii(const std::string& hex)
 
 std::string CorelliumAdapter::RunMonitorCommand(const std::string& command)
 {
-	std::string commandToSend = "qRcmd,";
-	for (const auto& c: command)
-	{
-		commandToSend += ("0123456789abcdef"[(c >> 4) & 0x0F]);
-		commandToSend += ("0123456789abcdef"[c & 0x0F]);
-	}
+    std::string commandToSend = "qRcmd,";
+    for (const auto& c: command)
+    {
+        commandToSend += ("0123456789abcdef"[(c >> 4) & 0x0F]);
+        commandToSend += ("0123456789abcdef"[c & 0x0F]);
+    }
 
-	m_rspConnector->SendPayload(RspData(commandToSend));
-	m_rspConnector->ExpectAck();
+    m_rspConnector->SendPayload(RspData(commandToSend));
+    m_rspConnector->ExpectAck();
 
-	std::string result;
-	while (true)
-	{
-		auto replyChunk = this->m_rspConnector->ReceiveRspData();
-		if (replyChunk.AsString() == "OK" || replyChunk.AsString().empty())
-			break;
+    std::string result;
+    while (true)
+    {
+        auto replyChunk = this->m_rspConnector->ReceiveRspData();
+        if (replyChunk.AsString() == "OK" || replyChunk.AsString().empty())
+            break;
 
-		if (replyChunk.m_data[0] != 'O')
-			break;
+        if (replyChunk.m_data[0] != 'O')
+            break;
 
         result += HexToAscii(replyChunk.AsString().erase(0, 1));
-	}
+    }
 
-	return result;
+    return result;
 }
 
 
@@ -930,7 +930,7 @@ uint64_t CorelliumAdapter::GetInstructionOffset()
     else
         ipRegisterName = "pc";
 
-	uint64_t value = (uint64_t)this->ReadRegister(ipRegisterName).m_value;
+    uint64_t value = (uint64_t)this->ReadRegister(ipRegisterName).m_value;
     return value;
 }
 

--- a/core/adapters/esrevenadapter.cpp
+++ b/core/adapters/esrevenadapter.cpp
@@ -559,12 +559,12 @@ bool EsrevenAdapter::WriteRegister(const std::string& reg, intx::uint512 value)
     if (m_isTargetRunning || !m_rspConnector)
         return false;
 
-	if (!this->m_registerInfo.contains(reg))
-		return false;
+    if (!this->m_registerInfo.contains(reg))
+        return false;
 
-	const auto newRegString = uint512ToLittleEndianHex(value, this->m_registerInfo[reg].m_bitSize / 8);
-	const auto reply = this->m_rspConnector->TransmitAndReceive(RspData("P{:02X}={}",
-									   this->m_registerInfo[reg].m_regNum, newRegString));
+    const auto newRegString = uint512ToLittleEndianHex(value, this->m_registerInfo[reg].m_bitSize / 8);
+    const auto reply = this->m_rspConnector->TransmitAndReceive(RspData("P{:02X}={}",
+                                       this->m_registerInfo[reg].m_regNum, newRegString));
 
     if (reply.m_data[0])
         return true;
@@ -573,16 +573,16 @@ bool EsrevenAdapter::WriteRegister(const std::string& reg, intx::uint512 value)
     const auto generic_query = this->m_rspConnector->TransmitAndReceive(RspData(&query, sizeof(query)));
     const auto register_offset = this->m_registerInfo[reg].m_offset;
 
-	// TODO: check if this works for aarch64
+    // TODO: check if this works for aarch64
     const auto first_half = generic_query.AsString().substr(0, 2 * (register_offset / 8));
     const auto second_half = generic_query.AsString().substr(2 * ((register_offset + this->m_registerInfo[reg].m_bitSize) / 8) );
-	const auto payload = "G" + first_half + newRegString + second_half;
+    const auto payload = "G" + first_half + newRegString + second_half;
 
     if ( this->m_rspConnector->TransmitAndReceive(RspData(payload)).AsString() != "OK" )
         return false;
 
-	// TODO: we do not need to invalidate all register caches, we could probably just update the necessary ones here
-	InvalidateCache();
+    // TODO: we do not need to invalidate all register caches, we could probably just update the necessary ones here
+    InvalidateCache();
     return true;
 }
 
@@ -1431,7 +1431,7 @@ uint64_t EsrevenAdapter::GetInstructionOffset()
     else
         ipRegisterName = "pc";
 
-	uint64_t value = (uint64_t)this->ReadRegister(ipRegisterName).m_value;
+    uint64_t value = (uint64_t)this->ReadRegister(ipRegisterName).m_value;
     return value;
 }
 

--- a/core/adapters/gdbadapter.cpp
+++ b/core/adapters/gdbadapter.cpp
@@ -557,10 +557,10 @@ bool GdbAdapter::WriteRegister(const std::string& reg, intx::uint512 value)
     if (m_isTargetRunning || !m_rspConnector)
         return false;
 
-	if (!this->m_registerInfo.contains(reg))
-		return false;
+    if (!this->m_registerInfo.contains(reg))
+        return false;
 
-	const auto newRegString = uint512ToLittleEndianHex(value, this->m_registerInfo[reg].m_bitSize / 8);
+    const auto newRegString = uint512ToLittleEndianHex(value, this->m_registerInfo[reg].m_bitSize / 8);
     const auto reply = this->m_rspConnector->TransmitAndReceive(RspData("P{:02X}={}",
                                        this->m_registerInfo[reg].m_regNum, newRegString));
     if (reply.m_data[0])
@@ -570,7 +570,7 @@ bool GdbAdapter::WriteRegister(const std::string& reg, intx::uint512 value)
     const auto generic_query = this->m_rspConnector->TransmitAndReceive(RspData(&query, sizeof(query)));
     const auto register_offset = this->m_registerInfo[reg].m_offset;
 
-	// TODO: check if this works for aarch64
+    // TODO: check if this works for aarch64
     const auto first_half = generic_query.AsString().substr(0, 2 * (register_offset / 8));
     const auto second_half = generic_query.AsString().substr(2 * ((register_offset + this->m_registerInfo[reg].m_bitSize) / 8) );
     const auto payload = "G" + first_half + newRegString + second_half;
@@ -578,8 +578,8 @@ bool GdbAdapter::WriteRegister(const std::string& reg, intx::uint512 value)
     if ( this->m_rspConnector->TransmitAndReceive(RspData(payload)).AsString() != "OK" )
         return false;
 
-	// TODO: we do not need to invalidate all register caches, we could probably just update the necessary ones here
-	InvalidateCache();
+    // TODO: we do not need to invalidate all register caches, we could probably just update the necessary ones here
+    InvalidateCache();
     return true;
 }
 
@@ -1230,7 +1230,7 @@ uint64_t GdbAdapter::GetInstructionOffset()
     else
         ipRegisterName = "pc";
 
-	uint64_t value = (uint64_t)this->ReadRegister(ipRegisterName).m_value;
+    uint64_t value = (uint64_t)this->ReadRegister(ipRegisterName).m_value;
     return value;
 }
 

--- a/core/adapters/gdbmiadapter.cpp
+++ b/core/adapters/gdbmiadapter.cpp
@@ -111,30 +111,30 @@ void GdbMiAdapter::UpdateAllRegisters() {
         LogError("Failed to get register values: %s", result.fullLine.c_str());
         return;
     }
-    
+
     std::unordered_map<std::string, DebugRegister> regs;
 
-	auto gdbmiregisters = MiValue::Parse(result.payload);
-	if (!gdbmiregisters.IsDict() || !gdbmiregisters["register-values"].IsList())
-	{
-		LogError("No register-values in response. Payload: %s", result.payload.c_str());
-		return;
-	}
+    auto gdbmiregisters = MiValue::Parse(result.payload);
+    if (!gdbmiregisters.IsDict() || !gdbmiregisters["register-values"].IsList())
+    {
+        LogError("No register-values in response. Payload: %s", result.payload.c_str());
+        return;
+    }
 
-	for (int i = 0; i < gdbmiregisters["register-values"].size(); i++)
-	{
-		auto gdbmi_reg = gdbmiregisters["register-values"][i];
-		auto reg_idx = std::stoul(gdbmi_reg["number"].GetString(), 0, 10);
-		auto reg_value = ParseGdbValue(gdbmi_reg["value"].GetString());
-		if (reg_idx < m_registerNames.size())
-		{
-			std::string name = m_registerNames[reg_idx];
-			if (!name.empty())
-			{
-				regs[name] = DebugRegister(name, reg_value, 0, reg_idx);
-			}
-		}
-	}
+    for (size_t i = 0; i < gdbmiregisters["register-values"].size(); i++)
+    {
+        auto gdbmi_reg = gdbmiregisters["register-values"][i];
+        auto reg_idx = std::stoul(gdbmi_reg["number"].GetString(), 0, 10);
+        auto reg_value = ParseGdbValue(gdbmi_reg["value"].GetString());
+        if (reg_idx < m_registerNames.size())
+        {
+            std::string name = m_registerNames[reg_idx];
+            if (!name.empty())
+            {
+                regs[name] = DebugRegister(name, reg_value, 0, reg_idx);
+            }
+        }
+    }
 
     std::unique_lock cacheLock(m_cacheMutex);
     m_cachedRegisters = regs;
@@ -153,7 +153,7 @@ void GdbMiAdapter::UpdateStackFrames(uint32_t tid) {
 
     std::vector<DebugFrame> frames;
 	auto gdbmi_frames = MiValue::Parse(result.payload);
-	for (int i = 0; i < gdbmi_frames["stack"].size(); ++i)
+	for (size_t i = 0; i < gdbmi_frames["stack"].size(); ++i)
 	{
 		auto parsed_frame = gdbmi_frames["stack"][i];
 		auto debug_frame = DebugFrame(i,


### PR DESCRIPTION
Many of the warnings were related to misleading indentation due to code within a function using a mixture of tabs and spaces. This could lead to code after single-line if statements potentially appearing to be indented to the level of the if statement body, depending on how the editor displayed tabs vs spaces.