### PR TITLE
Added Conditional Breakpoint Support

### DIFF
--- a/api/debuggerapi.h
+++ b/api/debuggerapi.h
@@ -360,6 +360,7 @@ namespace BinaryNinjaDebuggerAPI {
 		uint64_t offset;
 		uint64_t address;
 		bool enabled;
+		std::string condition;
 	};
 
 

--- a/api/debuggerapi.h
+++ b/api/debuggerapi.h
@@ -726,6 +726,10 @@ namespace BinaryNinjaDebuggerAPI {
 		void DisableBreakpoint(const ModuleNameAndOffset& breakpoint);
 		bool ContainsBreakpoint(uint64_t address);
 		bool ContainsBreakpoint(const ModuleNameAndOffset& breakpoint);
+		bool SetBreakpointCondition(uint64_t address, const std::string& condition);
+		bool SetBreakpointCondition(const ModuleNameAndOffset& address, const std::string& condition);
+		std::string GetBreakpointCondition(uint64_t address);
+		std::string GetBreakpointCondition(const ModuleNameAndOffset& address);
 
 		uint64_t IP();
 		uint64_t GetLastIP();

--- a/api/debuggercontroller.cpp
+++ b/api/debuggercontroller.cpp
@@ -799,6 +799,36 @@ bool DebuggerController::ContainsBreakpoint(const ModuleNameAndOffset& breakpoin
 }
 
 
+bool DebuggerController::SetBreakpointCondition(uint64_t address, const std::string& condition)
+{
+	return BNDebuggerSetBreakpointConditionAbsolute(m_object, address, condition.c_str());
+}
+
+
+bool DebuggerController::SetBreakpointCondition(const ModuleNameAndOffset& address, const std::string& condition)
+{
+	return BNDebuggerSetBreakpointConditionRelative(m_object, address.module.c_str(), address.offset, condition.c_str());
+}
+
+
+std::string DebuggerController::GetBreakpointCondition(uint64_t address)
+{
+	char* condition = BNDebuggerGetBreakpointConditionAbsolute(m_object, address);
+	std::string result = condition ? condition : "";
+	BNDebuggerFreeString(condition);
+	return result;
+}
+
+
+std::string DebuggerController::GetBreakpointCondition(const ModuleNameAndOffset& address)
+{
+	char* condition = BNDebuggerGetBreakpointConditionRelative(m_object, address.module.c_str(), address.offset);
+	std::string result = condition ? condition : "";
+	BNDebuggerFreeString(condition);
+	return result;
+}
+
+
 uint64_t DebuggerController::RelativeAddressToAbsolute(const ModuleNameAndOffset& address)
 {
 	return BNDebuggerRelativeAddressToAbsolute(m_object, address.module.c_str(), address.offset);

--- a/api/debuggercontroller.cpp
+++ b/api/debuggercontroller.cpp
@@ -731,6 +731,7 @@ std::vector<DebugBreakpoint> DebuggerController::GetBreakpoints()
 		bp.offset = breakpoints[i].offset;
 		bp.address = breakpoints[i].address;
 		bp.enabled = breakpoints[i].enabled;
+		bp.condition = breakpoints[i].condition ? breakpoints[i].condition : "";
 		result[i] = bp;
 	}
 

--- a/api/ffi.h
+++ b/api/ffi.h
@@ -257,6 +257,8 @@ extern "C"
 		RelativeBreakpointEnabledEvent,
 		AbsoluteBreakpointDisabledEvent,
 		RelativeBreakpointDisabledEvent,
+		AbsoluteBreakpointConditionChangedEvent,
+		RelativeBreakpointConditionChangedEvent,
 
 		ActiveThreadChangedEvent,
 

--- a/api/ffi.h
+++ b/api/ffi.h
@@ -132,6 +132,7 @@ extern "C"
 		uint64_t offset;
 		uint64_t address;
 		bool enabled;
+		char* condition;  // NULL if no condition
 	} BNDebugBreakpoint;
 
 
@@ -595,6 +596,15 @@ extern "C"
 		BNDebuggerController* controller, const char* module, uint64_t offset);
 	DEBUGGER_FFI_API bool BNDebuggerContainsAbsoluteBreakpoint(BNDebuggerController* controller, uint64_t address);
 	DEBUGGER_FFI_API bool BNDebuggerContainsRelativeBreakpoint(
+		BNDebuggerController* controller, const char* module, uint64_t offset);
+
+	DEBUGGER_FFI_API bool BNDebuggerSetBreakpointConditionAbsolute(
+		BNDebuggerController* controller, uint64_t address, const char* condition);
+	DEBUGGER_FFI_API bool BNDebuggerSetBreakpointConditionRelative(
+		BNDebuggerController* controller, const char* module, uint64_t offset, const char* condition);
+	DEBUGGER_FFI_API char* BNDebuggerGetBreakpointConditionAbsolute(
+		BNDebuggerController* controller, uint64_t address);
+	DEBUGGER_FFI_API char* BNDebuggerGetBreakpointConditionRelative(
 		BNDebuggerController* controller, const char* module, uint64_t offset);
 
 	DEBUGGER_FFI_API uint64_t BNDebuggerGetIP(BNDebuggerController* controller);

--- a/api/python/debuggercontroller.py
+++ b/api/python/debuggercontroller.py
@@ -368,19 +368,21 @@ class DebugBreakpoint:
     * ``offset``: the offset of the breakpoint to the start of the module
     * ``address``: the absolute address of the breakpoint
     * ``enabled``: whether the breakpoint is enabled (read-only)
+    * ``condition``: the condition expression for the breakpoint (empty if no condition)
 
     """
-    def __init__(self, module, offset, address, enabled):
+    def __init__(self, module, offset, address, enabled, condition=""):
         self.module = module
         self.offset = offset
         self.address = address
         self.enabled = enabled
+        self.condition = condition
 
     def __eq__(self, other):
         if not isinstance(other, self.__class__):
             return NotImplemented
         return self.module == other.module and self.offset == other.offset and self.address == other.address \
-               and self.enabled == other.enabled
+               and self.enabled == other.enabled and self.condition == other.condition
 
     def __ne__(self, other):
         if not isinstance(other, self.__class__):
@@ -2053,7 +2055,8 @@ class DebuggerController:
         breakpoints = dbgcore.BNDebuggerGetBreakpoints(self.handle, count)
         result = []
         for i in range(0, count.value):
-            bp = DebugBreakpoint(breakpoints[i].module, breakpoints[i].offset, breakpoints[i].address, breakpoints[i].enabled)
+            condition = breakpoints[i].condition if breakpoints[i].condition else ""
+            bp = DebugBreakpoint(breakpoints[i].module, breakpoints[i].offset, breakpoints[i].address, breakpoints[i].enabled, condition)
             result.append(bp)
 
         dbgcore.BNDebuggerFreeBreakpoints(breakpoints, count.value)
@@ -2138,6 +2141,49 @@ class DebuggerController:
             dbgcore.BNDebuggerDisableRelativeBreakpoint(self.handle, address.module, address.offset)
         else:
             raise NotImplementedError
+
+    def set_breakpoint_condition(self, address, condition: str) -> bool:
+        """
+        Set a condition for a breakpoint
+
+        The condition is an expression that will be evaluated using Binary Ninja's expression parser
+        when the breakpoint is hit. If the condition evaluates to non-zero (true), the debugger stops.
+        If it evaluates to zero (false), the debugger silently continues execution.
+
+        Example conditions:
+        - ``"$rax == 0x1234"`` - break when RAX equals 0x1234
+        - ``"$rsp + 0x20"`` - break when the expression is non-zero
+
+        Pass an empty string to clear the condition.
+
+        :param address: the address of the breakpoint (int or ModuleNameAndOffset)
+        :param condition: the condition expression, or empty string to clear
+        :return: True if successful, False otherwise
+        """
+        if isinstance(address, int):
+            return dbgcore.BNDebuggerSetBreakpointConditionAbsolute(self.handle, address, condition.encode('utf-8') if condition else None)
+        elif isinstance(address, ModuleNameAndOffset):
+            return dbgcore.BNDebuggerSetBreakpointConditionRelative(self.handle, address.module.encode('utf-8'), address.offset, condition.encode('utf-8') if condition else None)
+        else:
+            raise NotImplementedError
+
+    def get_breakpoint_condition(self, address) -> str:
+        """
+        Get the condition for a breakpoint
+
+        :param address: the address of the breakpoint (int or ModuleNameAndOffset)
+        :return: the condition expression, or empty string if no condition
+        """
+        if isinstance(address, int):
+            result = dbgcore.BNDebuggerGetBreakpointConditionAbsolute(self.handle, address)
+        elif isinstance(address, ModuleNameAndOffset):
+            result = dbgcore.BNDebuggerGetBreakpointConditionRelative(self.handle, address.module.encode('utf-8'), address.offset)
+        else:
+            raise NotImplementedError
+
+        condition = result.decode('utf-8') if result else ""
+        dbgcore.BNDebuggerFreeString(result)
+        return condition
 
     @property
     def ip(self) -> int:

--- a/api/python/debuggercontroller.py
+++ b/api/python/debuggercontroller.py
@@ -2181,9 +2181,7 @@ class DebuggerController:
         else:
             raise NotImplementedError
 
-        condition = result.decode('utf-8') if result else ""
-        dbgcore.BNDebuggerFreeString(result)
-        return condition
+        return result if result else ""
 
     @property
     def ip(self) -> int:

--- a/api/python/debuggercontroller.py
+++ b/api/python/debuggercontroller.py
@@ -382,7 +382,7 @@ class DebugBreakpoint:
         if not isinstance(other, self.__class__):
             return NotImplemented
         return self.module == other.module and self.offset == other.offset and self.address == other.address \
-               and self.enabled == other.enabled and self.condition == other.condition
+               and self.enabled == other.enabled
 
     def __ne__(self, other):
         if not isinstance(other, self.__class__):
@@ -2161,9 +2161,9 @@ class DebuggerController:
         :return: True if successful, False otherwise
         """
         if isinstance(address, int):
-            return dbgcore.BNDebuggerSetBreakpointConditionAbsolute(self.handle, address, condition.encode('utf-8') if condition else None)
+            return dbgcore.BNDebuggerSetBreakpointConditionAbsolute(self.handle, address, condition)
         elif isinstance(address, ModuleNameAndOffset):
-            return dbgcore.BNDebuggerSetBreakpointConditionRelative(self.handle, address.module.encode('utf-8'), address.offset, condition.encode('utf-8') if condition else None)
+            return dbgcore.BNDebuggerSetBreakpointConditionRelative(self.handle, address.module, address.offset, condition)
         else:
             raise NotImplementedError
 
@@ -2177,7 +2177,7 @@ class DebuggerController:
         if isinstance(address, int):
             result = dbgcore.BNDebuggerGetBreakpointConditionAbsolute(self.handle, address)
         elif isinstance(address, ModuleNameAndOffset):
-            result = dbgcore.BNDebuggerGetBreakpointConditionRelative(self.handle, address.module.encode('utf-8'), address.offset)
+            result = dbgcore.BNDebuggerGetBreakpointConditionRelative(self.handle, address.module, address.offset)
         else:
             raise NotImplementedError
 

--- a/core/debuggercontroller.cpp
+++ b/core/debuggercontroller.cpp
@@ -2453,11 +2453,10 @@ void DebuggerController::AddModuleValuesToExpressionParser()
 
 bool DebuggerController::EvaluateBreakpointCondition(uint64_t address)
 {
-	DebuggerBreakpoints* breakpoints = m_state->GetBreakpoints();
-	if (!breakpoints->HasConditionAbsolute(address))
+	const std::string condition = m_state->GetBreakpoints()->GetConditionAbsolute(address);
+	if (condition.empty())
 		return true;  // no condition means always break
 
-	const std::string condition = breakpoints->GetConditionAbsolute(address);
 	uint64_t result = 0;
 	std::string errorString;
 

--- a/core/debuggercontroller.cpp
+++ b/core/debuggercontroller.cpp
@@ -2004,7 +2004,9 @@ void DebuggerController::DebuggerMainThread()
 				{
 					m_lastAdapterStopEventConsumed = true;
 					current->done.set_value();
-					Go();
+					// using m_adapter->Go() directly instead of Go() to avoid mutex deadlock
+					// since we're already inside ExecuteAdapterAndWait's event processing
+					m_adapter->Go();
 					continue;
 				}
 			}

--- a/core/debuggercontroller.cpp
+++ b/core/debuggercontroller.cpp
@@ -32,7 +32,6 @@ DebuggerController::DebuggerController(BinaryViewRef data): BinaryDataNotificati
 	m_data = data;
 	m_data->RegisterNotification(this);
 	m_viewStart = m_data->GetStart();
-	m_originalFileBase = m_data->GetStart();
 
 	m_state = new DebuggerState(data, this);
 	m_adapter = nullptr;

--- a/core/debuggercontroller.cpp
+++ b/core/debuggercontroller.cpp
@@ -140,6 +140,30 @@ void DebuggerController::DisableBreakpoint(const ModuleNameAndOffset& address)
 }
 
 
+bool DebuggerController::SetBreakpointCondition(uint64_t address, const std::string& condition)
+{
+	return m_state->GetBreakpoints()->SetConditionAbsolute(address, condition);
+}
+
+
+bool DebuggerController::SetBreakpointCondition(const ModuleNameAndOffset& address, const std::string& condition)
+{
+	return m_state->GetBreakpoints()->SetConditionOffset(address, condition);
+}
+
+
+std::string DebuggerController::GetBreakpointCondition(uint64_t address)
+{
+	return m_state->GetBreakpoints()->GetConditionAbsolute(address);
+}
+
+
+std::string DebuggerController::GetBreakpointCondition(const ModuleNameAndOffset& address)
+{
+	return m_state->GetBreakpoints()->GetConditionOffset(address);
+}
+
+
 bool DebuggerController::SetIP(uint64_t address)
 {
 	std::string ipRegisterName;
@@ -1963,6 +1987,29 @@ void DebuggerController::DebuggerMainThread()
 		if (event.type == AdapterStoppedEventType)
 			m_lastAdapterStopEventConsumed = false;
 
+		if (event.type == AdapterStoppedEventType &&
+			event.data.targetStoppedData.reason == Breakpoint)
+		{
+			// update the caches so registers are available for condition evaluation
+			m_state->SetConnectionStatus(DebugAdapterConnectedStatus);
+			m_state->SetExecutionStatus(DebugAdapterPausedStatus);
+			m_state->MarkDirty();
+			m_state->UpdateCaches();
+			AddRegisterValuesToExpressionParser();
+			AddModuleValuesToExpressionParser();
+
+			if (uint64_t ip = m_state->IP(); m_state->GetBreakpoints()->ContainsAbsolute(ip))
+			{
+				if (!EvaluateBreakpointCondition(ip))
+				{
+					m_lastAdapterStopEventConsumed = true;
+					current->done.set_value();
+					Go();
+					continue;
+				}
+			}
+		}
+
 		DebuggerEvent eventToSend = event;
 		if ((eventToSend.type == TargetStoppedEventType) && !m_initialBreakpointSeen)
 		{
@@ -2398,6 +2445,31 @@ void DebuggerController::AddModuleValuesToExpressionParser()
 	}
 
 	GetData()->AddExpressionParserMagicValues(names, values);
+}
+
+
+bool DebuggerController::EvaluateBreakpointCondition(uint64_t address)
+{
+	DebuggerBreakpoints* breakpoints = m_state->GetBreakpoints();
+	if (!breakpoints->HasConditionAbsolute(address))
+		return true;  // no condition means always break
+
+	const std::string condition = breakpoints->GetConditionAbsolute(address);
+	if (condition.empty())
+		return true;
+
+	uint64_t result = 0;
+	std::string errorString;
+
+	if (const bool parseSuccess = BinaryView::ParseExpression(GetData(), condition, result, address, errorString);
+		!parseSuccess)
+	{
+		LogWarn("Failed to parse breakpoint condition '%s' at 0x%" PRIx64 ": %s",
+			condition.c_str(), address, errorString.c_str());
+		return true;  // parse failure means break (don't silently continue)
+	}
+
+	return result != 0;  // non-zero means condition is true
 }
 
 

--- a/core/debuggercontroller.cpp
+++ b/core/debuggercontroller.cpp
@@ -2458,9 +2458,6 @@ bool DebuggerController::EvaluateBreakpointCondition(uint64_t address)
 		return true;  // no condition means always break
 
 	const std::string condition = breakpoints->GetConditionAbsolute(address);
-	if (condition.empty())
-		return true;
-
 	uint64_t result = 0;
 	std::string errorString;
 

--- a/core/debuggercontroller.cpp
+++ b/core/debuggercontroller.cpp
@@ -143,13 +143,29 @@ void DebuggerController::DisableBreakpoint(const ModuleNameAndOffset& address)
 
 bool DebuggerController::SetBreakpointCondition(uint64_t address, const std::string& condition)
 {
-	return m_state->GetBreakpoints()->SetConditionAbsolute(address, condition);
+	bool result = m_state->GetBreakpoints()->SetConditionAbsolute(address, condition);
+	if (result)
+	{
+		DebuggerEvent event;
+		event.type = AbsoluteBreakpointConditionChangedEvent;
+		event.data.absoluteAddress = address;
+		PostDebuggerEvent(event);
+	}
+	return result;
 }
 
 
 bool DebuggerController::SetBreakpointCondition(const ModuleNameAndOffset& address, const std::string& condition)
 {
-	return m_state->GetBreakpoints()->SetConditionOffset(address, condition);
+	bool result = m_state->GetBreakpoints()->SetConditionOffset(address, condition);
+	if (result)
+	{
+		DebuggerEvent event;
+		event.type = RelativeBreakpointConditionChangedEvent;
+		event.data.relativeAddress = address;
+		PostDebuggerEvent(event);
+	}
+	return result;
 }
 
 

--- a/core/debuggercontroller.cpp
+++ b/core/debuggercontroller.cpp
@@ -32,6 +32,7 @@ DebuggerController::DebuggerController(BinaryViewRef data): BinaryDataNotificati
 	m_data = data;
 	m_data->RegisterNotification(this);
 	m_viewStart = m_data->GetStart();
+	m_originalFileBase = m_data->GetStart();
 
 	m_state = new DebuggerState(data, this);
 	m_adapter = nullptr;

--- a/core/debuggercontroller.h
+++ b/core/debuggercontroller.h
@@ -85,8 +85,6 @@ namespace BinaryNinjaDebugger {
 		// this does not change even if we add the debugger memory region. In the future, this should be provided by
 		// the binary view -- we will no longer need to track it ourselves
 		uint64_t m_viewStart;
-		// Preserves original file base before rebasing - never updated, used for file VA to offset conversion
-		uint64_t m_originalFileBase;
 
 		//	inline static std::vector<DbgRef<DebuggerController>> g_debuggerControllers;
 		static DbgRef<DebuggerController>* g_debuggerControllers;
@@ -395,7 +393,6 @@ namespace BinaryNinjaDebugger {
 		bool ReAddDebuggerMemoryRegion();
 
 		uint64_t GetViewFileSegmentsStart() { return m_viewStart; }
-		uint64_t GetOriginalFileBase() { return m_originalFileBase; }
 
 		bool ComputeExprValueAPI(const LowLevelILInstruction& instr, intx::uint512& value);
 		bool ComputeExprValue(const LowLevelILInstruction& instr, intx::uint512& value);

--- a/core/debuggercontroller.h
+++ b/core/debuggercontroller.h
@@ -85,6 +85,8 @@ namespace BinaryNinjaDebugger {
 		// this does not change even if we add the debugger memory region. In the future, this should be provided by
 		// the binary view -- we will no longer need to track it ourselves
 		uint64_t m_viewStart;
+		// Original file base address before any rebasing - used for file address lookups
+		uint64_t m_originalFileBase;
 
 		//	inline static std::vector<DbgRef<DebuggerController>> g_debuggerControllers;
 		static DbgRef<DebuggerController>* g_debuggerControllers;
@@ -393,6 +395,7 @@ namespace BinaryNinjaDebugger {
 		bool ReAddDebuggerMemoryRegion();
 
 		uint64_t GetViewFileSegmentsStart() { return m_viewStart; }
+		uint64_t GetOriginalFileBase() { return m_originalFileBase; }
 
 		bool ComputeExprValueAPI(const LowLevelILInstruction& instr, intx::uint512& value);
 		bool ComputeExprValue(const LowLevelILInstruction& instr, intx::uint512& value);

--- a/core/debuggercontroller.h
+++ b/core/debuggercontroller.h
@@ -85,7 +85,7 @@ namespace BinaryNinjaDebugger {
 		// this does not change even if we add the debugger memory region. In the future, this should be provided by
 		// the binary view -- we will no longer need to track it ourselves
 		uint64_t m_viewStart;
-		// Original file base address before any rebasing - used for file address lookups
+		// Preserves original file base before rebasing - never updated, used for file VA to offset conversion
 		uint64_t m_originalFileBase;
 
 		//	inline static std::vector<DbgRef<DebuggerController>> g_debuggerControllers;

--- a/core/debuggercontroller.h
+++ b/core/debuggercontroller.h
@@ -131,6 +131,7 @@ namespace BinaryNinjaDebugger {
 		void UpdateStackVariables();
 		void AddRegisterValuesToExpressionParser();
 		void AddModuleValuesToExpressionParser();
+		bool EvaluateBreakpointCondition(uint64_t address);
 		bool CreateDebuggerBinaryView();
 
 		DebugStopReason StepIntoIL(BNFunctionGraphType il);
@@ -233,6 +234,10 @@ namespace BinaryNinjaDebugger {
 		void DisableBreakpoint(uint64_t address);
 		void DisableBreakpoint(const ModuleNameAndOffset& address);
 		DebugBreakpoint GetAllBreakpoints();
+		bool SetBreakpointCondition(uint64_t address, const std::string& condition);
+		bool SetBreakpointCondition(const ModuleNameAndOffset& address, const std::string& condition);
+		std::string GetBreakpointCondition(uint64_t address);
+		std::string GetBreakpointCondition(const ModuleNameAndOffset& address);
 
 		// registers
 		intx::uint512 GetRegisterValue(const std::string& name);

--- a/core/debuggerstate.cpp
+++ b/core/debuggerstate.cpp
@@ -18,7 +18,6 @@ limitations under the License.
 #include <thread>
 #include <utility>
 #include <filesystem>
-#include <optional>
 #include "lowlevelilinstruction.h"
 #include "mediumlevelilinstruction.h"
 #include "highlevelilinstruction.h"
@@ -514,8 +513,40 @@ std::vector<DebugModule> DebuggerModules::GetAllModules()
 
 
 DebuggerBreakpoints::DebuggerBreakpoints(DebuggerState* state, std::vector<ModuleNameAndOffset> initial) :
-	m_state(state), m_breakpoints(std::move(initial))
-{}
+	m_state(state)
+{
+	for (const auto& addr : initial)
+		m_breakpoints.push_back({addr, true, ""});
+}
+
+
+BreakpointEntry* DebuggerBreakpoints::FindBreakpoint(const ModuleNameAndOffset& address)
+{
+	if (m_state->GetAdapter())
+	{
+		const uint64_t targetAbsolute = m_state->GetModules()->RelativeAddressToAbsolute(address);
+		for (auto& bp : m_breakpoints)
+		{
+			if (m_state->GetModules()->RelativeAddressToAbsolute(bp.address) == targetAbsolute)
+				return &bp;
+		}
+	}
+	else
+	{
+		for (auto& bp : m_breakpoints)
+		{
+			if (bp.address == address)
+				return &bp;
+		}
+	}
+	return nullptr;
+}
+
+
+const BreakpointEntry* DebuggerBreakpoints::FindBreakpoint(const ModuleNameAndOffset& address) const
+{
+	return const_cast<DebuggerBreakpoints*>(this)->FindBreakpoint(address);
+}
 
 
 bool DebuggerBreakpoints::AddAbsolute(uint64_t remoteAddress)
@@ -524,7 +555,6 @@ bool DebuggerBreakpoints::AddAbsolute(uint64_t remoteAddress)
 		return false;
 
 	bool result = false;
-	// Always add the breakpoint as long as the adapter is connected, even if it may be already present
 	if (m_state->IsConnected())
 	{
 		m_state->GetAdapter()->AddBreakpoint(remoteAddress);
@@ -534,8 +564,7 @@ bool DebuggerBreakpoints::AddAbsolute(uint64_t remoteAddress)
 	if (!ContainsAbsolute(remoteAddress))
 	{
 		ModuleNameAndOffset info = m_state->GetModules()->AbsoluteAddressToRelative(remoteAddress);
-		m_breakpoints.push_back(info);
-		m_enabledState[info] = true; // Enable by default
+		m_breakpoints.push_back({info, true, ""});
 		SerializeMetadata();
 	}
 
@@ -547,17 +576,12 @@ bool DebuggerBreakpoints::AddOffset(const ModuleNameAndOffset& address)
 {
 	if (!ContainsOffset(address))
 	{
-		m_breakpoints.push_back(address);
-		m_enabledState[address] = true; // Enable by default
+		m_breakpoints.push_back({address, true, ""});
 		SerializeMetadata();
 
-		// If the adapter is already created, we ask it to add the breakpoint.
-		// Otherwise, all breakpoints will be added to the adapter when the adapter is created.
 		if (m_state->GetAdapter() && m_state->IsConnected())
-		{
 			m_state->GetAdapter()->AddBreakpoint(address);
-			return true;
-		}
+
 		return true;
 	}
 	return false;
@@ -570,15 +594,14 @@ bool DebuggerBreakpoints::RemoveAbsolute(uint64_t remoteAddress)
 		return false;
 
 	ModuleNameAndOffset info = m_state->GetModules()->AbsoluteAddressToRelative(remoteAddress);
-	auto actualKey = FindBreakpointKey(info);
-	if (!actualKey)
+	BreakpointEntry* bp = FindBreakpoint(info);
+	if (!bp)
 		return false;
 
-	if (auto iter = std::ranges::find(m_breakpoints, *actualKey); iter != m_breakpoints.end())
-		m_breakpoints.erase(iter);
-
-	m_enabledState.erase(*actualKey);
-	m_conditions.erase(*actualKey);
+	auto it = std::find_if(m_breakpoints.begin(), m_breakpoints.end(),
+		[bp](const BreakpointEntry& b) { return &b == bp; });
+	if (it != m_breakpoints.end())
+		m_breakpoints.erase(it);
 	SerializeMetadata();
 	m_state->GetAdapter()->RemoveBreakpoint(remoteAddress);
 	return true;
@@ -587,20 +610,20 @@ bool DebuggerBreakpoints::RemoveAbsolute(uint64_t remoteAddress)
 
 bool DebuggerBreakpoints::RemoveOffset(const ModuleNameAndOffset& address)
 {
-	auto actualKey = FindBreakpointKey(address);
-	if (!actualKey)
+	BreakpointEntry* bp = FindBreakpoint(address);
+	if (!bp)
 		return false;
 
-	if (const auto iter = std::ranges::find(m_breakpoints, *actualKey); iter != m_breakpoints.end())
-		m_breakpoints.erase(iter);
-
-	m_enabledState.erase(*actualKey);
-	m_conditions.erase(*actualKey);
+	ModuleNameAndOffset actualAddr = bp->address;
+	auto it = std::find_if(m_breakpoints.begin(), m_breakpoints.end(),
+		[bp](const BreakpointEntry& b) { return &b == bp; });
+	if (it != m_breakpoints.end())
+		m_breakpoints.erase(it);
 	SerializeMetadata();
 
 	if (m_state->GetAdapter() && m_state->IsConnected())
 	{
-		uint64_t remoteAddress = m_state->GetModules()->RelativeAddressToAbsolute(*actualKey);
+		uint64_t remoteAddress = m_state->GetModules()->RelativeAddressToAbsolute(actualAddr);
 		m_state->GetAdapter()->RemoveBreakpoint(remoteAddress);
 	}
 	return true;
@@ -616,16 +639,16 @@ bool DebuggerBreakpoints::EnableAbsolute(uint64_t remoteAddress)
 
 bool DebuggerBreakpoints::EnableOffset(const ModuleNameAndOffset& address)
 {
-	auto actualKey = FindBreakpointKey(address);
-	if (!actualKey)
+	BreakpointEntry* bp = FindBreakpoint(address);
+	if (!bp)
 		return false;
 
-	m_enabledState[*actualKey] = true;
+	bp->enabled = true;
 	SerializeMetadata();
 
 	if (m_state->GetAdapter() && m_state->IsConnected())
 	{
-		uint64_t remoteAddress = m_state->GetModules()->RelativeAddressToAbsolute(*actualKey);
+		uint64_t remoteAddress = m_state->GetModules()->RelativeAddressToAbsolute(bp->address);
 		m_state->GetAdapter()->AddBreakpoint(remoteAddress);
 	}
 	return true;
@@ -641,16 +664,16 @@ bool DebuggerBreakpoints::DisableAbsolute(uint64_t remoteAddress)
 
 bool DebuggerBreakpoints::DisableOffset(const ModuleNameAndOffset& address)
 {
-	auto actualKey = FindBreakpointKey(address);
-	if (!actualKey)
+	BreakpointEntry* bp = FindBreakpoint(address);
+	if (!bp)
 		return false;
 
-	m_enabledState[*actualKey] = false;
+	bp->enabled = false;
 	SerializeMetadata();
 
 	if (m_state->GetAdapter() && m_state->IsConnected())
 	{
-		uint64_t remoteAddress = m_state->GetModules()->RelativeAddressToAbsolute(*actualKey);
+		uint64_t remoteAddress = m_state->GetModules()->RelativeAddressToAbsolute(bp->address);
 		m_state->GetAdapter()->RemoveBreakpoint(remoteAddress);
 	}
 	return true;
@@ -666,28 +689,17 @@ bool DebuggerBreakpoints::IsEnabledAbsolute(uint64_t address)
 
 bool DebuggerBreakpoints::IsEnabledOffset(const ModuleNameAndOffset& address)
 {
-	auto actualKey = FindBreakpointKey(address);
-	if (!actualKey)
+	const BreakpointEntry* bp = FindBreakpoint(address);
+	if (!bp)
 		return true;  // Default to enabled if breakpoint not found
 
-	auto iter = m_enabledState.find(*actualKey);
-	if (iter != m_enabledState.end())
-		return iter->second;
-
-	return true;  // Default to enabled if not explicitly set
+	return bp->enabled;
 }
 
 
 bool DebuggerBreakpoints::ContainsOffset(const ModuleNameAndOffset& address)
 {
-	// If there is no backend, then only check if the breakpoint is in the list
-	// This is useful when we deal with the breakpoint before the target is launched
-	if (!m_state->GetAdapter())
-		return std::find(m_breakpoints.begin(), m_breakpoints.end(), address) != m_breakpoints.end();
-
-	// When the backend is live, convert the relative address to absolute address and check its existence
-	uint64_t absolute = m_state->GetModules()->RelativeAddressToAbsolute(address);
-	return ContainsAbsolute(absolute);
+	return FindBreakpoint(address) != nullptr;
 }
 
 
@@ -696,14 +708,9 @@ bool DebuggerBreakpoints::ContainsAbsolute(uint64_t address)
 	if (!m_state->GetAdapter())
 		return false;
 
-	// We need to convert every ModuleAndOffset to absolute address and compare with the input address
-	// Because every ModuleAndOffset can be converted to an absolute address, but there is no guarantee that it works
-	// backward
-	// Well, that is because lldb does not report the size of the loaded libraries, so it is currently screwed up
-	for (const ModuleNameAndOffset& breakpoint : m_breakpoints)
+	for (const auto& bp : m_breakpoints)
 	{
-		uint64_t absolute = m_state->GetModules()->RelativeAddressToAbsolute(breakpoint);
-		if (absolute == address)
+		if (m_state->GetModules()->RelativeAddressToAbsolute(bp.address) == address)
 			return true;
 	}
 	return false;
@@ -719,46 +726,22 @@ bool DebuggerBreakpoints::SetConditionAbsolute(const uint64_t remoteAddress, con
 
 bool DebuggerBreakpoints::SetConditionOffset(const ModuleNameAndOffset& address, const std::string& condition)
 {
-	auto actualKey = FindBreakpointKey(address);
-	if (!actualKey)
+	BreakpointEntry* bp = FindBreakpoint(address);
+	if (!bp)
 		return false;
 
-	if (condition.empty())
-		m_conditions.erase(*actualKey);
-	else
-		m_conditions[*actualKey] = condition;
-
+	bp->condition = condition;
 	SerializeMetadata();
 	return true;
 }
 
 
-std::optional<ModuleNameAndOffset> DebuggerBreakpoints::FindBreakpointKey(const ModuleNameAndOffset& address)
-{
-	if (m_state->GetAdapter())
-	{
-		const uint64_t targetAbsolute = m_state->GetModules()->RelativeAddressToAbsolute(address);
-		for (const ModuleNameAndOffset& bp : m_breakpoints)
-		{
-			if (m_state->GetModules()->RelativeAddressToAbsolute(bp) == targetAbsolute)
-				return bp;
-		}
-	}
-	else
-	{
-		if (const auto it = std::ranges::find(m_breakpoints, address); it != m_breakpoints.end())
-			return *it;
-	}
-	return std::nullopt;
-}
-
-
 std::string DebuggerBreakpoints::GetConditionAbsolute(const uint64_t address)
 {
-	for (const auto& [key, condition] : m_conditions)
+	for (const auto& bp : m_breakpoints)
 	{
-		if (m_state->GetModules()->RelativeAddressToAbsolute(key) == address)
-			return condition;
+		if (m_state->GetModules()->RelativeAddressToAbsolute(bp.address) == address)
+			return bp.condition;
 	}
 	return "";
 }
@@ -766,22 +749,17 @@ std::string DebuggerBreakpoints::GetConditionAbsolute(const uint64_t address)
 
 std::string DebuggerBreakpoints::GetConditionOffset(const ModuleNameAndOffset& address)
 {
-	auto actualKey = FindBreakpointKey(address);
-	if (!actualKey)
-		return "";
-
-	if (const auto it = m_conditions.find(*actualKey); it != m_conditions.end())
-		return it->second;
-	return "";
+	const BreakpointEntry* bp = FindBreakpoint(address);
+	return bp ? bp->condition : "";
 }
 
 
 bool DebuggerBreakpoints::HasConditionAbsolute(const uint64_t address)
 {
-	for (const auto& [key, _] : m_conditions)
+	for (const auto& bp : m_breakpoints)
 	{
-		if (m_state->GetModules()->RelativeAddressToAbsolute(key) == address)
-			return true;
+		if (m_state->GetModules()->RelativeAddressToAbsolute(bp.address) == address)
+			return !bp.condition.empty();
 	}
 	return false;
 }
@@ -789,33 +767,23 @@ bool DebuggerBreakpoints::HasConditionAbsolute(const uint64_t address)
 
 bool DebuggerBreakpoints::HasConditionOffset(const ModuleNameAndOffset& address)
 {
-	auto actualKey = FindBreakpointKey(address);
-	if (!actualKey)
-		return false;
-
-	return m_conditions.contains(*actualKey);
+	const BreakpointEntry* bp = FindBreakpoint(address);
+	return bp && !bp->condition.empty();
 }
 
 
 void DebuggerBreakpoints::SerializeMetadata()
 {
-	// TODO: who should free these Metadata objects?
 	std::vector<Ref<Metadata>> breakpoints;
-	for (const ModuleNameAndOffset& bp : m_breakpoints)
+	for (const auto& bp : m_breakpoints)
 	{
 		std::map<std::string, Ref<Metadata>> info;
-		info["module"] = new Metadata(bp.module);
-		info["offset"] = new Metadata(bp.offset);
+		info["module"] = new Metadata(bp.address.module);
+		info["offset"] = new Metadata(bp.address.offset);
+		info["enabled"] = new Metadata(bp.enabled);
 
-		auto enabledIter = m_enabledState.find(bp);
-		const bool enabled = (enabledIter != m_enabledState.end()) ? enabledIter->second : true;
-		info["enabled"] = new Metadata(enabled);
-
-		if (auto conditionIter = m_conditions.find(bp);
-			conditionIter != m_conditions.end() && !conditionIter->second.empty())
-		{
-			info["condition"] = new Metadata(conditionIter->second);
-		}
+		if (!bp.condition.empty())
+			info["condition"] = new Metadata(bp.condition);
 
 		breakpoints.push_back(new Metadata(info));
 	}
@@ -826,46 +794,31 @@ void DebuggerBreakpoints::SerializeMetadata()
 void DebuggerBreakpoints::UnserializedMetadata()
 {
 	Ref<Metadata> metadata = m_state->GetController()->GetData()->QueryMetadata("debugger.breakpoints");
-	if (!metadata || (!metadata->IsArray()))
+	if (!metadata || !metadata->IsArray())
 		return;
 
-	vector<Ref<Metadata>> array = metadata->GetArray();
-	std::vector<ModuleNameAndOffset> newBreakpoints;
+	m_breakpoints.clear();
 
-	for (auto& element : array)
+	for (auto& element : metadata->GetArray())
 	{
-		if (!element || (!element->IsKeyValueStore()))
+		if (!element || !element->IsKeyValueStore())
 			continue;
 
 		std::map<std::string, Ref<Metadata>> info = element->GetKeyValueStore();
-		ModuleNameAndOffset address;
 
 		if (!(info["module"] && info["module"]->IsString()))
 			continue;
-
-		address.module = info["module"]->GetString();
-
 		if (!(info["offset"] && info["offset"]->IsUnsignedInteger()))
 			continue;
 
-		address.offset = info["offset"]->GetUnsignedInteger();
-		newBreakpoints.push_back(address);
+		BreakpointEntry bp;
+		bp.address.module = info["module"]->GetString();
+		bp.address.offset = info["offset"]->GetUnsignedInteger();
+		bp.enabled = (info["enabled"] && info["enabled"]->IsBoolean()) ? info["enabled"]->GetBoolean() : true;
+		bp.condition = (info["condition"] && info["condition"]->IsString()) ? info["condition"]->GetString() : "";
 
-		if (info["enabled"] && info["enabled"]->IsBoolean())
-		{
-			m_enabledState[address] = info["enabled"]->GetBoolean();
-		}
-
-		if (info["condition"] && info["condition"]->IsString())
-		{
-			if (std::string condition = info["condition"]->GetString(); !condition.empty())
-			{
-				m_conditions[address] = condition;
-			}
-		}
+		m_breakpoints.push_back(bp);
 	}
-
-	m_breakpoints = newBreakpoints;
 }
 
 
@@ -874,8 +827,11 @@ void DebuggerBreakpoints::Apply()
 	if (!m_state->GetAdapter())
 		return;
 
-	for (const ModuleNameAndOffset& address : m_breakpoints)
-		m_state->GetAdapter()->AddBreakpoint(address);
+	for (const auto& bp : m_breakpoints)
+	{
+		if (bp.enabled)
+			m_state->GetAdapter()->AddBreakpoint(bp.address);
+	}
 }
 
 

--- a/core/debuggerstate.cpp
+++ b/core/debuggerstate.cpp
@@ -577,6 +577,7 @@ bool DebuggerBreakpoints::RemoveAbsolute(uint64_t remoteAddress)
 			m_breakpoints.erase(iter);
 		}
 		m_enabledState.erase(info); // Remove enabled state
+		m_conditions.erase(info);   // Remove condition
 		SerializeMetadata();
 		m_state->GetAdapter()->RemoveBreakpoint(remoteAddress);
 		return true;
@@ -593,6 +594,7 @@ bool DebuggerBreakpoints::RemoveOffset(const ModuleNameAndOffset& address)
 			m_breakpoints.erase(iter);
 
 		m_enabledState.erase(address); // Remove enabled state
+		m_conditions.erase(address);   // Remove condition
 		SerializeMetadata();
 
 		if (m_state->GetAdapter() && m_state->IsConnected())
@@ -709,6 +711,74 @@ bool DebuggerBreakpoints::ContainsAbsolute(uint64_t address)
 }
 
 
+bool DebuggerBreakpoints::SetConditionAbsolute(const uint64_t remoteAddress, const std::string& condition)
+{
+	const ModuleNameAndOffset info = m_state->GetModules()->AbsoluteAddressToRelative(remoteAddress);
+	return SetConditionOffset(info, condition);
+}
+
+
+bool DebuggerBreakpoints::SetConditionOffset(const ModuleNameAndOffset& address, const std::string& condition)
+{
+	if (!ContainsOffset(address))
+		return false;
+
+	if (condition.empty())
+	{
+		m_conditions.erase(address);
+	}
+	else
+	{
+		m_conditions[address] = condition;
+	}
+	SerializeMetadata();
+	return true;
+}
+
+
+std::string DebuggerBreakpoints::GetConditionAbsolute(const uint64_t address)
+{
+	const ModuleNameAndOffset info = m_state->GetModules()->AbsoluteAddressToRelative(address);
+	return GetConditionOffset(info);
+}
+
+
+std::string DebuggerBreakpoints::GetConditionOffset(const ModuleNameAndOffset& address)
+{
+	if (const auto iter = m_conditions.find(address); iter != m_conditions.end())
+		return iter->second;
+	return "";
+}
+
+
+bool DebuggerBreakpoints::HasConditionAbsolute(const uint64_t address)
+{
+	const ModuleNameAndOffset info = m_state->GetModules()->AbsoluteAddressToRelative(address);
+	return HasConditionOffset(info);
+}
+
+
+bool DebuggerBreakpoints::HasConditionOffset(const ModuleNameAndOffset& address)
+{
+	const auto iter = m_conditions.find(address);
+	return (iter != m_conditions.end()) && !iter->second.empty();
+}
+
+
+void DebuggerBreakpoints::ClearConditionAbsolute(const uint64_t address)
+{
+	const ModuleNameAndOffset info = m_state->GetModules()->AbsoluteAddressToRelative(address);
+	ClearConditionOffset(info);
+}
+
+
+void DebuggerBreakpoints::ClearConditionOffset(const ModuleNameAndOffset& address)
+{
+	m_conditions.erase(address);
+	SerializeMetadata();
+}
+
+
 void DebuggerBreakpoints::SerializeMetadata()
 {
 	// TODO: who should free these Metadata objects?
@@ -718,6 +788,17 @@ void DebuggerBreakpoints::SerializeMetadata()
 		std::map<std::string, Ref<Metadata>> info;
 		info["module"] = new Metadata(bp.module);
 		info["offset"] = new Metadata(bp.offset);
+
+		auto enabledIter = m_enabledState.find(bp);
+		const bool enabled = (enabledIter != m_enabledState.end()) ? enabledIter->second : true;
+		info["enabled"] = new Metadata(enabled);
+
+		if (auto conditionIter = m_conditions.find(bp);
+			conditionIter != m_conditions.end() && !conditionIter->second.empty())
+		{
+			info["condition"] = new Metadata(conditionIter->second);
+		}
+
 		breakpoints.push_back(new Metadata(info));
 	}
 	m_state->GetController()->GetData()->StoreMetadata("debugger.breakpoints", new Metadata(breakpoints));
@@ -751,6 +832,19 @@ void DebuggerBreakpoints::UnserializedMetadata()
 
 		address.offset = info["offset"]->GetUnsignedInteger();
 		newBreakpoints.push_back(address);
+
+		if (info["enabled"] && info["enabled"]->IsBoolean())
+		{
+			m_enabledState[address] = info["enabled"]->GetBoolean();
+		}
+
+		if (info["condition"] && info["condition"]->IsString())
+		{
+			if (std::string condition = info["condition"]->GetString(); !condition.empty())
+			{
+				m_conditions[address] = condition;
+			}
+		}
 	}
 
 	m_breakpoints = newBreakpoints;

--- a/core/debuggerstate.cpp
+++ b/core/debuggerstate.cpp
@@ -721,17 +721,34 @@ bool DebuggerBreakpoints::SetConditionAbsolute(const uint64_t remoteAddress, con
 
 bool DebuggerBreakpoints::SetConditionOffset(const ModuleNameAndOffset& address, const std::string& condition)
 {
-	if (!ContainsOffset(address))
-		return false;
+	std::optional<ModuleNameAndOffset> actualKey;
 
-	if (condition.empty())
+	if (m_state->GetAdapter())
 	{
-		m_conditions.erase(address);
+		const uint64_t targetAbsolute = m_state->GetModules()->RelativeAddressToAbsolute(address);
+		for (const ModuleNameAndOffset& bp : m_breakpoints)
+		{
+			if (m_state->GetModules()->RelativeAddressToAbsolute(bp) == targetAbsolute)
+			{
+				actualKey = bp;
+				break;
+			}
+		}
 	}
 	else
 	{
-		m_conditions[address] = condition;
+		if (const auto it = std::ranges::find(m_breakpoints, address); it != m_breakpoints.end())
+			actualKey = *it;
 	}
+
+	if (!actualKey)
+		return false;
+
+	if (condition.empty())
+		m_conditions.erase(*actualKey);
+	else
+		m_conditions[*actualKey] = condition;
+
 	SerializeMetadata();
 	return true;
 }
@@ -797,9 +814,7 @@ bool DebuggerBreakpoints::HasConditionAbsolute(const uint64_t address)
 
 bool DebuggerBreakpoints::HasConditionOffset(const ModuleNameAndOffset& address)
 {
-	if (const auto key = FindConditionKey(address))
-		return !m_conditions[*key].empty();
-	return false;
+	return FindConditionKey(address).has_value();
 }
 
 

--- a/core/debuggerstate.cpp
+++ b/core/debuggerstate.cpp
@@ -27,8 +27,6 @@ limitations under the License.
 #include "debugadapter.h"
 #include "debuggercontroller.h"
 
-#include <ranges>
-
 using namespace BinaryNinja;
 using namespace std;
 using namespace BinaryNinjaDebugger;
@@ -747,7 +745,7 @@ std::optional<ModuleNameAndOffset> DebuggerBreakpoints::FindConditionKey(const M
 	// absolute address comparison (handles module name differences)
 	// assumes conditions are stored with valid, resolvable module names
 	const uint64_t targetAbsolute = m_state->GetModules()->RelativeAddressToAbsolute(address);
-	for (const auto& key : m_conditions | views::keys)
+	for (const auto& [key, _] : m_conditions)
 	{
 		if (const uint64_t conditionAbsolute = m_state->GetModules()->RelativeAddressToAbsolute(key);
 			conditionAbsolute == targetAbsolute)
@@ -763,7 +761,7 @@ std::optional<ModuleNameAndOffset> DebuggerBreakpoints::FindConditionKey(const M
 		{
 			const uint64_t fileOffset = address.offset - originalBase;
 			const std::string& mainFile = m_state->GetController()->GetData()->GetFile()->GetOriginalFilename();
-			for (const auto& key : m_conditions | views::keys)
+			for (const auto& [key, _] : m_conditions)
 			{
 				if (key.offset == fileOffset && DebugModule::IsSameBaseModule(mainFile, key.module))
 					return key;
@@ -802,23 +800,6 @@ bool DebuggerBreakpoints::HasConditionOffset(const ModuleNameAndOffset& address)
 	if (const auto key = FindConditionKey(address))
 		return !m_conditions[*key].empty();
 	return false;
-}
-
-
-void DebuggerBreakpoints::ClearConditionAbsolute(const uint64_t address)
-{
-	const ModuleNameAndOffset info = m_state->GetModules()->AbsoluteAddressToRelative(address);
-	ClearConditionOffset(info);
-}
-
-
-void DebuggerBreakpoints::ClearConditionOffset(const ModuleNameAndOffset& address)
-{
-	if (const auto key = FindConditionKey(address))
-	{
-		m_conditions.erase(*key);
-		SerializeMetadata();
-	}
 }
 
 

--- a/core/debuggerstate.cpp
+++ b/core/debuggerstate.cpp
@@ -520,30 +520,30 @@ DebuggerBreakpoints::DebuggerBreakpoints(DebuggerState* state, std::vector<Modul
 }
 
 
-BreakpointEntry* DebuggerBreakpoints::FindBreakpoint(const ModuleNameAndOffset& address)
+std::vector<BreakpointEntry>::iterator DebuggerBreakpoints::FindBreakpoint(const ModuleNameAndOffset& address)
 {
 	if (m_state->GetAdapter())
 	{
 		const uint64_t targetAbsolute = m_state->GetModules()->RelativeAddressToAbsolute(address);
-		for (auto& bp : m_breakpoints)
+		for (auto it = m_breakpoints.begin(); it != m_breakpoints.end(); ++it)
 		{
-			if (m_state->GetModules()->RelativeAddressToAbsolute(bp.address) == targetAbsolute)
-				return &bp;
+			if (m_state->GetModules()->RelativeAddressToAbsolute(it->address) == targetAbsolute)
+				return it;
 		}
 	}
 	else
 	{
-		for (auto& bp : m_breakpoints)
+		for (auto it = m_breakpoints.begin(); it != m_breakpoints.end(); ++it)
 		{
-			if (bp.address == address)
-				return &bp;
+			if (it->address == address)
+				return it;
 		}
 	}
-	return nullptr;
+	return m_breakpoints.end();
 }
 
 
-const BreakpointEntry* DebuggerBreakpoints::FindBreakpoint(const ModuleNameAndOffset& address) const
+std::vector<BreakpointEntry>::const_iterator DebuggerBreakpoints::FindBreakpoint(const ModuleNameAndOffset& address) const
 {
 	return const_cast<DebuggerBreakpoints*>(this)->FindBreakpoint(address);
 }
@@ -594,14 +594,11 @@ bool DebuggerBreakpoints::RemoveAbsolute(uint64_t remoteAddress)
 		return false;
 
 	ModuleNameAndOffset info = m_state->GetModules()->AbsoluteAddressToRelative(remoteAddress);
-	BreakpointEntry* bp = FindBreakpoint(info);
-	if (!bp)
+	auto it = FindBreakpoint(info);
+	if (it == m_breakpoints.end())
 		return false;
 
-	auto it = std::find_if(m_breakpoints.begin(), m_breakpoints.end(),
-		[bp](const BreakpointEntry& b) { return &b == bp; });
-	if (it != m_breakpoints.end())
-		m_breakpoints.erase(it);
+	m_breakpoints.erase(it);
 	SerializeMetadata();
 	m_state->GetAdapter()->RemoveBreakpoint(remoteAddress);
 	return true;
@@ -610,15 +607,12 @@ bool DebuggerBreakpoints::RemoveAbsolute(uint64_t remoteAddress)
 
 bool DebuggerBreakpoints::RemoveOffset(const ModuleNameAndOffset& address)
 {
-	BreakpointEntry* bp = FindBreakpoint(address);
-	if (!bp)
+	auto it = FindBreakpoint(address);
+	if (it == m_breakpoints.end())
 		return false;
 
-	ModuleNameAndOffset actualAddr = bp->address;
-	auto it = std::find_if(m_breakpoints.begin(), m_breakpoints.end(),
-		[bp](const BreakpointEntry& b) { return &b == bp; });
-	if (it != m_breakpoints.end())
-		m_breakpoints.erase(it);
+	ModuleNameAndOffset actualAddr = it->address;
+	m_breakpoints.erase(it);
 	SerializeMetadata();
 
 	if (m_state->GetAdapter() && m_state->IsConnected())
@@ -639,16 +633,16 @@ bool DebuggerBreakpoints::EnableAbsolute(uint64_t remoteAddress)
 
 bool DebuggerBreakpoints::EnableOffset(const ModuleNameAndOffset& address)
 {
-	BreakpointEntry* bp = FindBreakpoint(address);
-	if (!bp)
+	auto it = FindBreakpoint(address);
+	if (it == m_breakpoints.end())
 		return false;
 
-	bp->enabled = true;
+	it->enabled = true;
 	SerializeMetadata();
 
 	if (m_state->GetAdapter() && m_state->IsConnected())
 	{
-		uint64_t remoteAddress = m_state->GetModules()->RelativeAddressToAbsolute(bp->address);
+		uint64_t remoteAddress = m_state->GetModules()->RelativeAddressToAbsolute(it->address);
 		m_state->GetAdapter()->AddBreakpoint(remoteAddress);
 	}
 	return true;
@@ -664,16 +658,16 @@ bool DebuggerBreakpoints::DisableAbsolute(uint64_t remoteAddress)
 
 bool DebuggerBreakpoints::DisableOffset(const ModuleNameAndOffset& address)
 {
-	BreakpointEntry* bp = FindBreakpoint(address);
-	if (!bp)
+	auto it = FindBreakpoint(address);
+	if (it == m_breakpoints.end())
 		return false;
 
-	bp->enabled = false;
+	it->enabled = false;
 	SerializeMetadata();
 
 	if (m_state->GetAdapter() && m_state->IsConnected())
 	{
-		uint64_t remoteAddress = m_state->GetModules()->RelativeAddressToAbsolute(bp->address);
+		uint64_t remoteAddress = m_state->GetModules()->RelativeAddressToAbsolute(it->address);
 		m_state->GetAdapter()->RemoveBreakpoint(remoteAddress);
 	}
 	return true;
@@ -689,17 +683,17 @@ bool DebuggerBreakpoints::IsEnabledAbsolute(uint64_t address)
 
 bool DebuggerBreakpoints::IsEnabledOffset(const ModuleNameAndOffset& address)
 {
-	const BreakpointEntry* bp = FindBreakpoint(address);
-	if (!bp)
+	auto it = FindBreakpoint(address);
+	if (it == m_breakpoints.end())
 		return true;  // Default to enabled if breakpoint not found
 
-	return bp->enabled;
+	return it->enabled;
 }
 
 
 bool DebuggerBreakpoints::ContainsOffset(const ModuleNameAndOffset& address)
 {
-	return FindBreakpoint(address) != nullptr;
+	return FindBreakpoint(address) != m_breakpoints.end();
 }
 
 
@@ -726,11 +720,11 @@ bool DebuggerBreakpoints::SetConditionAbsolute(const uint64_t remoteAddress, con
 
 bool DebuggerBreakpoints::SetConditionOffset(const ModuleNameAndOffset& address, const std::string& condition)
 {
-	BreakpointEntry* bp = FindBreakpoint(address);
-	if (!bp)
+	auto it = FindBreakpoint(address);
+	if (it == m_breakpoints.end())
 		return false;
 
-	bp->condition = condition;
+	it->condition = condition;
 	SerializeMetadata();
 	return true;
 }
@@ -749,8 +743,8 @@ std::string DebuggerBreakpoints::GetConditionAbsolute(const uint64_t address)
 
 std::string DebuggerBreakpoints::GetConditionOffset(const ModuleNameAndOffset& address)
 {
-	const BreakpointEntry* bp = FindBreakpoint(address);
-	return bp ? bp->condition : "";
+	auto it = FindBreakpoint(address);
+	return it != m_breakpoints.end() ? it->condition : "";
 }
 
 
@@ -767,8 +761,8 @@ bool DebuggerBreakpoints::HasConditionAbsolute(const uint64_t address)
 
 bool DebuggerBreakpoints::HasConditionOffset(const ModuleNameAndOffset& address)
 {
-	const BreakpointEntry* bp = FindBreakpoint(address);
-	return bp && !bp->condition.empty();
+	auto it = FindBreakpoint(address);
+	return it != m_breakpoints.end() && !it->condition.empty();
 }
 
 

--- a/core/debuggerstate.cpp
+++ b/core/debuggerstate.cpp
@@ -18,6 +18,7 @@ limitations under the License.
 #include <thread>
 #include <utility>
 #include <filesystem>
+#include <optional>
 #include "lowlevelilinstruction.h"
 #include "mediumlevelilinstruction.h"
 #include "highlevelilinstruction.h"
@@ -25,6 +26,8 @@ limitations under the License.
 #include "debuggerstate.h"
 #include "debugadapter.h"
 #include "debuggercontroller.h"
+
+#include <ranges>
 
 using namespace BinaryNinja;
 using namespace std;
@@ -736,6 +739,42 @@ bool DebuggerBreakpoints::SetConditionOffset(const ModuleNameAndOffset& address,
 }
 
 
+std::optional<ModuleNameAndOffset> DebuggerBreakpoints::FindConditionKey(const ModuleNameAndOffset& address)
+{
+	if (m_conditions.contains(address))
+		return address;
+
+	// absolute address comparison (handles module name differences)
+	// assumes conditions are stored with valid, resolvable module names
+	const uint64_t targetAbsolute = m_state->GetModules()->RelativeAddressToAbsolute(address);
+	for (const auto& key : m_conditions | views::keys)
+	{
+		if (const uint64_t conditionAbsolute = m_state->GetModules()->RelativeAddressToAbsolute(key);
+			conditionAbsolute == targetAbsolute)
+			return key;
+	}
+
+	// if the address has empty module name, it might be a file virtual address?
+	// try converting to an offset by subtracting the original file base.
+	if (address.module.empty())
+	{
+		if (const uint64_t originalBase = m_state->GetController()->GetOriginalFileBase();
+			address.offset >= originalBase)
+		{
+			const uint64_t fileOffset = address.offset - originalBase;
+			const std::string& mainFile = m_state->GetController()->GetData()->GetFile()->GetOriginalFilename();
+			for (const auto& key : m_conditions | views::keys)
+			{
+				if (key.offset == fileOffset && DebugModule::IsSameBaseModule(mainFile, key.module))
+					return key;
+			}
+		}
+	}
+
+	return std::nullopt;
+}
+
+
 std::string DebuggerBreakpoints::GetConditionAbsolute(const uint64_t address)
 {
 	const ModuleNameAndOffset info = m_state->GetModules()->AbsoluteAddressToRelative(address);
@@ -745,17 +784,8 @@ std::string DebuggerBreakpoints::GetConditionAbsolute(const uint64_t address)
 
 std::string DebuggerBreakpoints::GetConditionOffset(const ModuleNameAndOffset& address)
 {
-	if (const auto iter = m_conditions.find(address); iter != m_conditions.end())
-		return iter->second;
-
-	// fall back to absolute address comparison (handles module name differences)
-	const uint64_t targetAbsolute = m_state->GetModules()->RelativeAddressToAbsolute(address);
-	for (const auto& [key, val] : m_conditions)
-	{
-		if (const uint64_t conditionAbsolute = m_state->GetModules()->RelativeAddressToAbsolute(key);
-			conditionAbsolute == targetAbsolute)
-			return val;
-	}
+	if (const auto key = FindConditionKey(address))
+		return m_conditions[*key];
 	return "";
 }
 
@@ -769,17 +799,8 @@ bool DebuggerBreakpoints::HasConditionAbsolute(const uint64_t address)
 
 bool DebuggerBreakpoints::HasConditionOffset(const ModuleNameAndOffset& address)
 {
-	if (const auto iter = m_conditions.find(address); iter != m_conditions.end())
-		return !iter->second.empty();
-
-	// fall back to absolute address comparison (handles module name differences)
-	const uint64_t targetAbsolute = m_state->GetModules()->RelativeAddressToAbsolute(address);
-	for (const auto& [key, val] : m_conditions)
-	{
-		if (const uint64_t conditionAbsolute = m_state->GetModules()->RelativeAddressToAbsolute(key);
-			conditionAbsolute == targetAbsolute && !val.empty())
-			return true;
-	}
+	if (const auto key = FindConditionKey(address))
+		return !m_conditions[*key].empty();
 	return false;
 }
 
@@ -793,8 +814,11 @@ void DebuggerBreakpoints::ClearConditionAbsolute(const uint64_t address)
 
 void DebuggerBreakpoints::ClearConditionOffset(const ModuleNameAndOffset& address)
 {
-	m_conditions.erase(address);
-	SerializeMetadata();
+	if (const auto key = FindConditionKey(address))
+	{
+		m_conditions.erase(*key);
+		SerializeMetadata();
+	}
 }
 
 

--- a/core/debuggerstate.cpp
+++ b/core/debuggerstate.cpp
@@ -753,67 +753,47 @@ std::optional<ModuleNameAndOffset> DebuggerBreakpoints::FindBreakpointKey(const 
 }
 
 
-std::optional<ModuleNameAndOffset> DebuggerBreakpoints::FindConditionKey(const ModuleNameAndOffset& address)
-{
-	if (m_conditions.contains(address))
-		return address;
-
-	// absolute address comparison (handles module name differences)
-	// assumes conditions are stored with valid, resolvable module names
-	const uint64_t targetAbsolute = m_state->GetModules()->RelativeAddressToAbsolute(address);
-	for (const auto& [key, _] : m_conditions)
-	{
-		if (const uint64_t conditionAbsolute = m_state->GetModules()->RelativeAddressToAbsolute(key);
-			conditionAbsolute == targetAbsolute)
-			return key;
-	}
-
-	// if the address has empty module name, it might be a file virtual address?
-	// try converting to an offset by subtracting the original file base.
-	if (address.module.empty())
-	{
-		if (const uint64_t originalBase = m_state->GetController()->GetOriginalFileBase();
-			address.offset >= originalBase)
-		{
-			const uint64_t fileOffset = address.offset - originalBase;
-			const std::string& mainFile = m_state->GetController()->GetData()->GetFile()->GetOriginalFilename();
-			for (const auto& [key, _] : m_conditions)
-			{
-				if (key.offset == fileOffset && DebugModule::IsSameBaseModule(mainFile, key.module))
-					return key;
-			}
-		}
-	}
-
-	return std::nullopt;
-}
-
-
 std::string DebuggerBreakpoints::GetConditionAbsolute(const uint64_t address)
 {
-	const ModuleNameAndOffset info = m_state->GetModules()->AbsoluteAddressToRelative(address);
-	return GetConditionOffset(info);
+	for (const auto& [key, condition] : m_conditions)
+	{
+		if (m_state->GetModules()->RelativeAddressToAbsolute(key) == address)
+			return condition;
+	}
+	return "";
 }
 
 
 std::string DebuggerBreakpoints::GetConditionOffset(const ModuleNameAndOffset& address)
 {
-	if (const auto key = FindConditionKey(address))
-		return m_conditions[*key];
+	auto actualKey = FindBreakpointKey(address);
+	if (!actualKey)
+		return "";
+
+	if (const auto it = m_conditions.find(*actualKey); it != m_conditions.end())
+		return it->second;
 	return "";
 }
 
 
 bool DebuggerBreakpoints::HasConditionAbsolute(const uint64_t address)
 {
-	const ModuleNameAndOffset info = m_state->GetModules()->AbsoluteAddressToRelative(address);
-	return HasConditionOffset(info);
+	for (const auto& [key, _] : m_conditions)
+	{
+		if (m_state->GetModules()->RelativeAddressToAbsolute(key) == address)
+			return true;
+	}
+	return false;
 }
 
 
 bool DebuggerBreakpoints::HasConditionOffset(const ModuleNameAndOffset& address)
 {
-	return FindConditionKey(address).has_value();
+	auto actualKey = FindBreakpointKey(address);
+	if (!actualKey)
+		return false;
+
+	return m_conditions.contains(*actualKey);
 }
 
 

--- a/core/debuggerstate.cpp
+++ b/core/debuggerstate.cpp
@@ -570,43 +570,40 @@ bool DebuggerBreakpoints::RemoveAbsolute(uint64_t remoteAddress)
 		return false;
 
 	ModuleNameAndOffset info = m_state->GetModules()->AbsoluteAddressToRelative(remoteAddress);
-	if (ContainsOffset(info))
-	{
-		auto iter = std::find(m_breakpoints.begin(), m_breakpoints.end(), info);
-		if (iter != m_breakpoints.end())
-		{
-			m_breakpoints.erase(iter);
-		}
-		m_enabledState.erase(info); // Remove enabled state
-		m_conditions.erase(info);   // Remove condition
-		SerializeMetadata();
-		m_state->GetAdapter()->RemoveBreakpoint(remoteAddress);
-		return true;
-	}
-	return false;
+	auto actualKey = FindBreakpointKey(info);
+	if (!actualKey)
+		return false;
+
+	if (auto iter = std::ranges::find(m_breakpoints, *actualKey); iter != m_breakpoints.end())
+		m_breakpoints.erase(iter);
+
+	m_enabledState.erase(*actualKey);
+	m_conditions.erase(*actualKey);
+	SerializeMetadata();
+	m_state->GetAdapter()->RemoveBreakpoint(remoteAddress);
+	return true;
 }
 
 
 bool DebuggerBreakpoints::RemoveOffset(const ModuleNameAndOffset& address)
 {
-	if (ContainsOffset(address))
+	auto actualKey = FindBreakpointKey(address);
+	if (!actualKey)
+		return false;
+
+	if (const auto iter = std::ranges::find(m_breakpoints, *actualKey); iter != m_breakpoints.end())
+		m_breakpoints.erase(iter);
+
+	m_enabledState.erase(*actualKey);
+	m_conditions.erase(*actualKey);
+	SerializeMetadata();
+
+	if (m_state->GetAdapter() && m_state->IsConnected())
 	{
-		if (auto iter = std::find(m_breakpoints.begin(), m_breakpoints.end(), address); iter != m_breakpoints.end())
-			m_breakpoints.erase(iter);
-
-		m_enabledState.erase(address); // Remove enabled state
-		m_conditions.erase(address);   // Remove condition
-		SerializeMetadata();
-
-		if (m_state->GetAdapter() && m_state->IsConnected())
-		{
-			uint64_t remoteAddress = m_state->GetModules()->RelativeAddressToAbsolute(address);
-			m_state->GetAdapter()->RemoveBreakpoint(remoteAddress);
-			return true;
-		}
-		return true;
+		uint64_t remoteAddress = m_state->GetModules()->RelativeAddressToAbsolute(*actualKey);
+		m_state->GetAdapter()->RemoveBreakpoint(remoteAddress);
 	}
-	return false;
+	return true;
 }
 
 
@@ -619,18 +616,17 @@ bool DebuggerBreakpoints::EnableAbsolute(uint64_t remoteAddress)
 
 bool DebuggerBreakpoints::EnableOffset(const ModuleNameAndOffset& address)
 {
-	if (!ContainsOffset(address))
+	auto actualKey = FindBreakpointKey(address);
+	if (!actualKey)
 		return false;
 
-	m_enabledState[address] = true;
+	m_enabledState[*actualKey] = true;
 	SerializeMetadata();
 
-	// If connected, make sure the breakpoint is active in the target
 	if (m_state->GetAdapter() && m_state->IsConnected())
 	{
-		uint64_t remoteAddress = m_state->GetModules()->RelativeAddressToAbsolute(address);
+		uint64_t remoteAddress = m_state->GetModules()->RelativeAddressToAbsolute(*actualKey);
 		m_state->GetAdapter()->AddBreakpoint(remoteAddress);
-		return true;
 	}
 	return true;
 }
@@ -645,18 +641,17 @@ bool DebuggerBreakpoints::DisableAbsolute(uint64_t remoteAddress)
 
 bool DebuggerBreakpoints::DisableOffset(const ModuleNameAndOffset& address)
 {
-	if (!ContainsOffset(address))
+	auto actualKey = FindBreakpointKey(address);
+	if (!actualKey)
 		return false;
 
-	m_enabledState[address] = false;
+	m_enabledState[*actualKey] = false;
 	SerializeMetadata();
 
-	// If connected, remove the breakpoint from the target but keep it in our list
 	if (m_state->GetAdapter() && m_state->IsConnected())
 	{
-		uint64_t remoteAddress = m_state->GetModules()->RelativeAddressToAbsolute(address);
+		uint64_t remoteAddress = m_state->GetModules()->RelativeAddressToAbsolute(*actualKey);
 		m_state->GetAdapter()->RemoveBreakpoint(remoteAddress);
-		return true;
 	}
 	return true;
 }
@@ -671,12 +666,15 @@ bool DebuggerBreakpoints::IsEnabledAbsolute(uint64_t address)
 
 bool DebuggerBreakpoints::IsEnabledOffset(const ModuleNameAndOffset& address)
 {
-	auto iter = m_enabledState.find(address);
+	auto actualKey = FindBreakpointKey(address);
+	if (!actualKey)
+		return true;  // Default to enabled if breakpoint not found
+
+	auto iter = m_enabledState.find(*actualKey);
 	if (iter != m_enabledState.end())
 		return iter->second;
-	
-	// Default to enabled if not explicitly set
-	return true;
+
+	return true;  // Default to enabled if not explicitly set
 }
 
 
@@ -721,26 +719,7 @@ bool DebuggerBreakpoints::SetConditionAbsolute(const uint64_t remoteAddress, con
 
 bool DebuggerBreakpoints::SetConditionOffset(const ModuleNameAndOffset& address, const std::string& condition)
 {
-	std::optional<ModuleNameAndOffset> actualKey;
-
-	if (m_state->GetAdapter())
-	{
-		const uint64_t targetAbsolute = m_state->GetModules()->RelativeAddressToAbsolute(address);
-		for (const ModuleNameAndOffset& bp : m_breakpoints)
-		{
-			if (m_state->GetModules()->RelativeAddressToAbsolute(bp) == targetAbsolute)
-			{
-				actualKey = bp;
-				break;
-			}
-		}
-	}
-	else
-	{
-		if (const auto it = std::ranges::find(m_breakpoints, address); it != m_breakpoints.end())
-			actualKey = *it;
-	}
-
+	auto actualKey = FindBreakpointKey(address);
 	if (!actualKey)
 		return false;
 
@@ -751,6 +730,26 @@ bool DebuggerBreakpoints::SetConditionOffset(const ModuleNameAndOffset& address,
 
 	SerializeMetadata();
 	return true;
+}
+
+
+std::optional<ModuleNameAndOffset> DebuggerBreakpoints::FindBreakpointKey(const ModuleNameAndOffset& address)
+{
+	if (m_state->GetAdapter())
+	{
+		const uint64_t targetAbsolute = m_state->GetModules()->RelativeAddressToAbsolute(address);
+		for (const ModuleNameAndOffset& bp : m_breakpoints)
+		{
+			if (m_state->GetModules()->RelativeAddressToAbsolute(bp) == targetAbsolute)
+				return bp;
+		}
+	}
+	else
+	{
+		if (const auto it = std::ranges::find(m_breakpoints, address); it != m_breakpoints.end())
+			return *it;
+	}
+	return std::nullopt;
 }
 
 

--- a/core/debuggerstate.cpp
+++ b/core/debuggerstate.cpp
@@ -747,6 +747,15 @@ std::string DebuggerBreakpoints::GetConditionOffset(const ModuleNameAndOffset& a
 {
 	if (const auto iter = m_conditions.find(address); iter != m_conditions.end())
 		return iter->second;
+
+	// fall back to absolute address comparison (handles module name differences)
+	const uint64_t targetAbsolute = m_state->GetModules()->RelativeAddressToAbsolute(address);
+	for (const auto& [key, val] : m_conditions)
+	{
+		if (const uint64_t conditionAbsolute = m_state->GetModules()->RelativeAddressToAbsolute(key);
+			conditionAbsolute == targetAbsolute)
+			return val;
+	}
 	return "";
 }
 
@@ -760,8 +769,18 @@ bool DebuggerBreakpoints::HasConditionAbsolute(const uint64_t address)
 
 bool DebuggerBreakpoints::HasConditionOffset(const ModuleNameAndOffset& address)
 {
-	const auto iter = m_conditions.find(address);
-	return (iter != m_conditions.end()) && !iter->second.empty();
+	if (const auto iter = m_conditions.find(address); iter != m_conditions.end())
+		return !iter->second.empty();
+
+	// fall back to absolute address comparison (handles module name differences)
+	const uint64_t targetAbsolute = m_state->GetModules()->RelativeAddressToAbsolute(address);
+	for (const auto& [key, val] : m_conditions)
+	{
+		if (const uint64_t conditionAbsolute = m_state->GetModules()->RelativeAddressToAbsolute(key);
+			conditionAbsolute == targetAbsolute && !val.empty())
+			return true;
+	}
+	return false;
 }
 
 

--- a/core/debuggerstate.h
+++ b/core/debuggerstate.h
@@ -119,8 +119,8 @@ namespace BinaryNinjaDebugger {
 
 	private:
 		// Find breakpoint by address, handling module name differences via absolute address comparison
-		BreakpointEntry* FindBreakpoint(const ModuleNameAndOffset& address);
-		const BreakpointEntry* FindBreakpoint(const ModuleNameAndOffset& address) const;
+		std::vector<BreakpointEntry>::iterator FindBreakpoint(const ModuleNameAndOffset& address);
+		std::vector<BreakpointEntry>::const_iterator FindBreakpoint(const ModuleNameAndOffset& address) const;
 	};
 
 

--- a/core/debuggerstate.h
+++ b/core/debuggerstate.h
@@ -116,10 +116,6 @@ namespace BinaryNinjaDebugger {
 		// Helper to find the actual key in m_breakpoints matching the given address,
 		// handling module name differences via absolute address comparison
 		std::optional<ModuleNameAndOffset> FindBreakpointKey(const ModuleNameAndOffset& address);
-
-		// Helper to find the actual key in m_conditions matching the given address,
-		// handling module name differences and file address fallback
-		std::optional<ModuleNameAndOffset> FindConditionKey(const ModuleNameAndOffset& address);
 	};
 
 

--- a/core/debuggerstate.h
+++ b/core/debuggerstate.h
@@ -113,6 +113,11 @@ namespace BinaryNinjaDebugger {
 		bool HasConditionOffset(const ModuleNameAndOffset& address);
 		void ClearConditionAbsolute(uint64_t address);
 		void ClearConditionOffset(const ModuleNameAndOffset& address);
+
+	private:
+		// Helper to find the actual key in m_conditions matching the given address,
+		// handling module name differences and file address fallback
+		std::optional<ModuleNameAndOffset> FindConditionKey(const ModuleNameAndOffset& address);
 	};
 
 

--- a/core/debuggerstate.h
+++ b/core/debuggerstate.h
@@ -113,6 +113,10 @@ namespace BinaryNinjaDebugger {
 		bool HasConditionOffset(const ModuleNameAndOffset& address);
 
 	private:
+		// Helper to find the actual key in m_breakpoints matching the given address,
+		// handling module name differences via absolute address comparison
+		std::optional<ModuleNameAndOffset> FindBreakpointKey(const ModuleNameAndOffset& address);
+
 		// Helper to find the actual key in m_conditions matching the given address,
 		// handling module name differences and file address fallback
 		std::optional<ModuleNameAndOffset> FindConditionKey(const ModuleNameAndOffset& address);

--- a/core/debuggerstate.h
+++ b/core/debuggerstate.h
@@ -111,8 +111,6 @@ namespace BinaryNinjaDebugger {
 		std::string GetConditionOffset(const ModuleNameAndOffset& address);
 		bool HasConditionAbsolute(uint64_t address);
 		bool HasConditionOffset(const ModuleNameAndOffset& address);
-		void ClearConditionAbsolute(uint64_t address);
-		void ClearConditionOffset(const ModuleNameAndOffset& address);
 
 	private:
 		// Helper to find the actual key in m_conditions matching the given address,

--- a/core/debuggerstate.h
+++ b/core/debuggerstate.h
@@ -84,6 +84,7 @@ namespace BinaryNinjaDebugger {
 		DebuggerState* m_state;
 		std::vector<ModuleNameAndOffset> m_breakpoints;
 		std::map<ModuleNameAndOffset, bool> m_enabledState;
+		std::map<ModuleNameAndOffset, std::string> m_conditions;
 
 	public:
 		DebuggerBreakpoints(DebuggerState* state, std::vector<ModuleNameAndOffset> initial = {});
@@ -103,6 +104,15 @@ namespace BinaryNinjaDebugger {
 		void SerializeMetadata();
 		void UnserializedMetadata();
 		std::vector<ModuleNameAndOffset> GetBreakpointList() const { return m_breakpoints; }
+
+		bool SetConditionAbsolute(uint64_t remoteAddress, const std::string& condition);
+		bool SetConditionOffset(const ModuleNameAndOffset& address, const std::string& condition);
+		std::string GetConditionAbsolute(uint64_t address);
+		std::string GetConditionOffset(const ModuleNameAndOffset& address);
+		bool HasConditionAbsolute(uint64_t address);
+		bool HasConditionOffset(const ModuleNameAndOffset& address);
+		void ClearConditionAbsolute(uint64_t address);
+		void ClearConditionOffset(const ModuleNameAndOffset& address);
 	};
 
 

--- a/core/debuggerstate.h
+++ b/core/debuggerstate.h
@@ -78,13 +78,18 @@ namespace BinaryNinjaDebugger {
 	};
 
 
+	struct BreakpointEntry
+	{
+		ModuleNameAndOffset address;
+		bool enabled = true;
+		std::string condition;
+	};
+
 	class DebuggerBreakpoints
 	{
 	private:
 		DebuggerState* m_state;
-		std::vector<ModuleNameAndOffset> m_breakpoints;
-		std::map<ModuleNameAndOffset, bool> m_enabledState;
-		std::map<ModuleNameAndOffset, std::string> m_conditions;
+		std::vector<BreakpointEntry> m_breakpoints;
 
 	public:
 		DebuggerBreakpoints(DebuggerState* state, std::vector<ModuleNameAndOffset> initial = {});
@@ -103,7 +108,7 @@ namespace BinaryNinjaDebugger {
 		void Apply();
 		void SerializeMetadata();
 		void UnserializedMetadata();
-		std::vector<ModuleNameAndOffset> GetBreakpointList() const { return m_breakpoints; }
+		std::vector<BreakpointEntry> GetBreakpointList() const { return m_breakpoints; }
 
 		bool SetConditionAbsolute(uint64_t remoteAddress, const std::string& condition);
 		bool SetConditionOffset(const ModuleNameAndOffset& address, const std::string& condition);
@@ -113,9 +118,9 @@ namespace BinaryNinjaDebugger {
 		bool HasConditionOffset(const ModuleNameAndOffset& address);
 
 	private:
-		// Helper to find the actual key in m_breakpoints matching the given address,
-		// handling module name differences via absolute address comparison
-		std::optional<ModuleNameAndOffset> FindBreakpointKey(const ModuleNameAndOffset& address);
+		// Find breakpoint by address, handling module name differences via absolute address comparison
+		BreakpointEntry* FindBreakpoint(const ModuleNameAndOffset& address);
+		const BreakpointEntry* FindBreakpoint(const ModuleNameAndOffset& address) const;
 	};
 
 

--- a/core/ffi.cpp
+++ b/core/ffi.cpp
@@ -797,29 +797,21 @@ void BNDebuggerSetCommandLineArguments(BNDebuggerController* controller, const c
 }
 
 
-// TODO: the structures to hold information about the breakpoints are different in the API and the core, so we need to
-// convert it here. Better unify them later.
 BNDebugBreakpoint* BNDebuggerGetBreakpoints(BNDebuggerController* controller, size_t* count)
 {
 	DebuggerState* state = controller->object->GetState();
-	std::vector<ModuleNameAndOffset> breakpoints = state->GetBreakpoints()->GetBreakpointList();
+	const auto& breakpoints = state->GetBreakpoints()->GetBreakpointList();
 	*count = breakpoints.size();
-
-	//std::vector<DebugBreakpoint> remoteList;
-	//if (state->IsConnected() && state->GetAdapter())
-	//	remoteList = state->GetAdapter()->GetBreakpointList();
 
 	BNDebugBreakpoint* result = new BNDebugBreakpoint[breakpoints.size()];
 	for (size_t i = 0; i < breakpoints.size(); i++)
 	{
-		uint64_t remoteAddress = state->GetModules()->RelativeAddressToAbsolute(breakpoints[i]);
-		bool enabled = state->GetBreakpoints()->IsEnabledOffset(breakpoints[i]);
-		std::string condition = state->GetBreakpoints()->GetConditionOffset(breakpoints[i]);
-		result[i].module = BNDebuggerAllocString(breakpoints[i].module.c_str());
-		result[i].offset = breakpoints[i].offset;
-		result[i].address = remoteAddress;
-		result[i].enabled = enabled;
-		result[i].condition = condition.empty() ? nullptr : BNDebuggerAllocString(condition.c_str());
+		const auto& bp = breakpoints[i];
+		result[i].module = BNDebuggerAllocString(bp.address.module.c_str());
+		result[i].offset = bp.address.offset;
+		result[i].address = state->GetModules()->RelativeAddressToAbsolute(bp.address);
+		result[i].enabled = bp.enabled;
+		result[i].condition = bp.condition.empty() ? nullptr : BNDebuggerAllocString(bp.condition.c_str());
 	}
 	return result;
 }

--- a/core/ffi.cpp
+++ b/core/ffi.cpp
@@ -945,31 +945,13 @@ bool BNDebuggerSetBreakpointConditionRelative(BNDebuggerController* controller, 
 
 char* BNDebuggerGetBreakpointConditionAbsolute(BNDebuggerController* controller, uint64_t address)
 {
-	const DebuggerState* state = controller->object->GetState();
-	if (!state)
-		return BNDebuggerAllocString("");
-
-	DebuggerBreakpoints* breakpoints = state->GetBreakpoints();
-	if (!breakpoints)
-		return BNDebuggerAllocString("");
-
-	const std::string condition = breakpoints->GetConditionAbsolute(address);
-	return BNDebuggerAllocString(condition.c_str());
+	return BNDebuggerAllocString(controller->object->GetBreakpointCondition(address).c_str());
 }
 
 
 char* BNDebuggerGetBreakpointConditionRelative(BNDebuggerController* controller, const char* module, uint64_t offset)
 {
-	const DebuggerState* state = controller->object->GetState();
-	if (!state)
-		return BNDebuggerAllocString("");
-
-	DebuggerBreakpoints* breakpoints = state->GetBreakpoints();
-	if (!breakpoints)
-		return BNDebuggerAllocString("");
-
-	const std::string condition = breakpoints->GetConditionOffset(ModuleNameAndOffset(module, offset));
-	return BNDebuggerAllocString(condition.c_str());
+	return BNDebuggerAllocString(controller->object->GetBreakpointCondition(ModuleNameAndOffset(module, offset)).c_str());
 }
 
 

--- a/core/ffi.cpp
+++ b/core/ffi.cpp
@@ -991,7 +991,7 @@ char* BNDebuggerGetBreakpointConditionRelative(BNDebuggerController* controller,
 
 uint64_t BNDebuggerRelativeAddressToAbsolute(BNDebuggerController* controller, const char* module, uint64_t offset)
 {
-	const DebuggerState* state = controller->object->GetState();
+	DebuggerState* state = controller->object->GetState();
 	if (!state)
 		return 0;
 

--- a/core/ffi.cpp
+++ b/core/ffi.cpp
@@ -814,10 +814,12 @@ BNDebugBreakpoint* BNDebuggerGetBreakpoints(BNDebuggerController* controller, si
 	{
 		uint64_t remoteAddress = state->GetModules()->RelativeAddressToAbsolute(breakpoints[i]);
 		bool enabled = state->GetBreakpoints()->IsEnabledOffset(breakpoints[i]);
+		std::string condition = state->GetBreakpoints()->GetConditionOffset(breakpoints[i]);
 		result[i].module = BNDebuggerAllocString(breakpoints[i].module.c_str());
 		result[i].offset = breakpoints[i].offset;
 		result[i].address = remoteAddress;
 		result[i].enabled = enabled;
+		result[i].condition = condition.empty() ? nullptr : BNDebuggerAllocString(condition.c_str());
 	}
 	return result;
 }
@@ -828,6 +830,8 @@ void BNDebuggerFreeBreakpoints(BNDebugBreakpoint* breakpoints, size_t count)
 	for (size_t i = 0; i < count; i++)
 	{
 		BNDebuggerFreeString(breakpoints[i].module);
+		if (breakpoints[i].condition)
+			BNDebuggerFreeString(breakpoints[i].condition);
 	}
 	delete[] breakpoints;
 }
@@ -927,9 +931,67 @@ bool BNDebuggerContainsRelativeBreakpoint(BNDebuggerController* controller, cons
 }
 
 
+bool BNDebuggerSetBreakpointConditionAbsolute(BNDebuggerController* controller, uint64_t address, const char* condition)
+{
+	const DebuggerState* state = controller->object->GetState();
+	if (!state)
+		return false;
+
+	DebuggerBreakpoints* breakpoints = state->GetBreakpoints();
+	if (!breakpoints)
+		return false;
+
+	return breakpoints->SetConditionAbsolute(address, condition ? condition : "");
+}
+
+
+bool BNDebuggerSetBreakpointConditionRelative(BNDebuggerController* controller, const char* module, uint64_t offset, const char* condition)
+{
+	const DebuggerState* state = controller->object->GetState();
+	if (!state)
+		return false;
+
+	DebuggerBreakpoints* breakpoints = state->GetBreakpoints();
+	if (!breakpoints)
+		return false;
+
+	return breakpoints->SetConditionOffset(ModuleNameAndOffset(module, offset), condition ? condition : "");
+}
+
+
+char* BNDebuggerGetBreakpointConditionAbsolute(BNDebuggerController* controller, uint64_t address)
+{
+	const DebuggerState* state = controller->object->GetState();
+	if (!state)
+		return BNDebuggerAllocString("");
+
+	DebuggerBreakpoints* breakpoints = state->GetBreakpoints();
+	if (!breakpoints)
+		return BNDebuggerAllocString("");
+
+	const std::string condition = breakpoints->GetConditionAbsolute(address);
+	return BNDebuggerAllocString(condition.c_str());
+}
+
+
+char* BNDebuggerGetBreakpointConditionRelative(BNDebuggerController* controller, const char* module, uint64_t offset)
+{
+	const DebuggerState* state = controller->object->GetState();
+	if (!state)
+		return BNDebuggerAllocString("");
+
+	DebuggerBreakpoints* breakpoints = state->GetBreakpoints();
+	if (!breakpoints)
+		return BNDebuggerAllocString("");
+
+	const std::string condition = breakpoints->GetConditionOffset(ModuleNameAndOffset(module, offset));
+	return BNDebuggerAllocString(condition.c_str());
+}
+
+
 uint64_t BNDebuggerRelativeAddressToAbsolute(BNDebuggerController* controller, const char* module, uint64_t offset)
 {
-	DebuggerState* state = controller->object->GetState();
+	const DebuggerState* state = controller->object->GetState();
 	if (!state)
 		return 0;
 

--- a/core/ffi.cpp
+++ b/core/ffi.cpp
@@ -933,29 +933,13 @@ bool BNDebuggerContainsRelativeBreakpoint(BNDebuggerController* controller, cons
 
 bool BNDebuggerSetBreakpointConditionAbsolute(BNDebuggerController* controller, uint64_t address, const char* condition)
 {
-	const DebuggerState* state = controller->object->GetState();
-	if (!state)
-		return false;
-
-	DebuggerBreakpoints* breakpoints = state->GetBreakpoints();
-	if (!breakpoints)
-		return false;
-
-	return breakpoints->SetConditionAbsolute(address, condition ? condition : "");
+	return controller->object->SetBreakpointCondition(address, condition ? condition : "");
 }
 
 
 bool BNDebuggerSetBreakpointConditionRelative(BNDebuggerController* controller, const char* module, uint64_t offset, const char* condition)
 {
-	const DebuggerState* state = controller->object->GetState();
-	if (!state)
-		return false;
-
-	DebuggerBreakpoints* breakpoints = state->GetBreakpoints();
-	if (!breakpoints)
-		return false;
-
-	return breakpoints->SetConditionOffset(ModuleNameAndOffset(module, offset), condition ? condition : "");
+	return controller->object->SetBreakpointCondition(ModuleNameAndOffset(module, offset), condition ? condition : "");
 }
 
 

--- a/test/debugger_test.py
+++ b/test/debugger_test.py
@@ -192,6 +192,38 @@ class DebuggerAPI(unittest.TestCase):
         self.assertEqual(dbg.ip, entry)
         dbg.quit_and_wait()
 
+    def test_breakpoint_condition(self):
+        fpath = name_to_fpath('helloworld', self.arch)
+        bv = load(fpath)
+        dbg = DebuggerController(bv)
+        self.assertNotIn(dbg.launch_and_wait(), [DebugStopReason.ProcessExited, DebugStopReason.InternalError])
+
+        entry = dbg.data.entry_point
+        dbg.add_breakpoint(entry)
+
+        arch_name = bv.arch.name
+        if arch_name == 'x86':
+            reg1, reg2 = '$eax', '$ebx'
+        elif arch_name == 'x86_64':
+            reg1, reg2 = '$rax', '$rbx'
+        else:
+            reg1, reg2 = '$x0', '$x1'
+
+        cond1 = f"{reg1} == 0x1234"
+        self.assertTrue(dbg.set_breakpoint_condition(entry, cond1))
+        self.assertEqual(dbg.get_breakpoint_condition(entry), cond1)
+
+        cond2 = f"{reg2} != 0"
+        self.assertTrue(dbg.set_breakpoint_condition(entry, cond2))
+        self.assertEqual(dbg.get_breakpoint_condition(entry), cond2)
+
+        self.assertTrue(dbg.set_breakpoint_condition(entry, ""))
+        self.assertEqual(dbg.get_breakpoint_condition(entry), "")
+
+        self.assertFalse(dbg.set_breakpoint_condition(0x12345678, f"{reg1} == 0"))
+        self.assertEqual(dbg.get_breakpoint_condition(0x12345678), "")
+        dbg.quit_and_wait()
+
     def test_register_read_write(self):
         fpath = name_to_fpath('helloworld', self.arch)
         bv = load(fpath)

--- a/ui/breakpointswidget.cpp
+++ b/ui/breakpointswidget.cpp
@@ -577,10 +577,7 @@ void DebugBreakpointsWidget::editCondition()
 		QLineEdit::Normal, QString::fromStdString(currentCondition), &ok);
 
 	if (ok)
-	{
 		m_controller->SetBreakpointCondition(bp.location(), newCondition.trimmed().toStdString());
-		updateContent();
-	}
 }
 
 

--- a/ui/breakpointswidget.cpp
+++ b/ui/breakpointswidget.cpp
@@ -23,6 +23,7 @@ limitations under the License.
 #include <QStringList>
 #include <algorithm>
 #include <QMouseEvent>
+#include <QInputDialog>
 #include "breakpointswidget.h"
 #include "ui.h"
 #include "menus.h"
@@ -32,13 +33,14 @@ using namespace BinaryNinjaDebuggerAPI;
 using namespace BinaryNinja;
 using namespace std;
 
-BreakpointItem::BreakpointItem(bool enabled, const ModuleNameAndOffset location, uint64_t address) :
-	m_enabled(enabled), m_location(location), m_address(address)
+BreakpointItem::BreakpointItem(bool enabled, const ModuleNameAndOffset location, uint64_t address, const std::string& condition) :
+	m_enabled(enabled), m_location(location), m_address(address), m_condition(condition)
 {}
 
 
 bool BreakpointItem::operator==(const BreakpointItem& other) const
 {
+	// Condition is not part of identity - same location = same breakpoint
 	return (m_enabled == other.enabled()) && (m_location == other.location()) && (m_address == other.address());
 }
 
@@ -100,7 +102,7 @@ QVariant DebugBreakpointsListModel::data(const QModelIndex& index, int role) con
 	if (!item)
 		return QVariant();
 
-	if ((role != Qt::DisplayRole) && (role != Qt::SizeHintRole))
+	if ((role != Qt::DisplayRole) && (role != Qt::SizeHintRole) && (role != Qt::ToolTipRole))
 		return QVariant();
 
 	switch (index.column())
@@ -138,6 +140,18 @@ QVariant DebugBreakpointsListModel::data(const QModelIndex& index, int role) con
 
 		return QVariant(text);
 	}
+	case DebugBreakpointsListModel::ConditionColumn:
+	{
+		QString condition = QString::fromStdString(item->condition());
+
+		if (role == Qt::ToolTipRole && !condition.isEmpty())
+			return QVariant(condition);
+
+		if (role == Qt::SizeHintRole)
+			return QVariant((qulonglong)condition.size());
+
+		return QVariant(condition);
+	}
 	}
 	return QVariant();
 }
@@ -159,6 +173,8 @@ QVariant DebugBreakpointsListModel::headerData(int column, Qt::Orientation orien
 		return "Location";
 	case DebugBreakpointsListModel::AddressColumn:
 		return "Remote Address";
+	case DebugBreakpointsListModel::ConditionColumn:
+		return "Condition";
 	}
 	return QVariant();
 }
@@ -205,6 +221,17 @@ void DebugBreakpointsItemDelegate::paint(
 		painter->setFont(m_font);
 		painter->setPen(option.palette.color(QPalette::WindowText).rgba());
 		painter->drawText(textRect, data.toString());
+		break;
+	}
+	case DebugBreakpointsListModel::ConditionColumn:
+	{
+		painter->setFont(m_font);
+		painter->setPen(option.palette.color(QPalette::WindowText).rgba());
+
+		QString text = data.toString();
+		QFontMetrics metrics(m_font);
+		QString elidedText = metrics.elidedText(text, Qt::ElideRight, textRect.width());
+		painter->drawText(textRect, elidedText);
 		break;
 	}
 	default:
@@ -297,6 +324,15 @@ DebugBreakpointsWidget::DebugBreakpointsWidget(ViewFrame* view, BinaryViewRef da
 	m_menu->addAction(toggleEnabledActionName, "Options", MENU_ORDER_NORMAL);
 	m_actionHandler.bindAction(
 		toggleEnabledActionName, UIAction([&]() { toggleSelected(); }, [&]() { return selectionNotEmpty(); }));
+
+	QString editConditionActionName = QString::fromStdString("Edit Condition...");
+	UIAction::registerAction(editConditionActionName);
+	m_menu->addAction(editConditionActionName, "Options", MENU_ORDER_NORMAL);
+	m_actionHandler.bindAction(
+		editConditionActionName, UIAction([&]() { editCondition(); }, [&]() {
+			QModelIndexList sel = selectionModel()->selectedRows();
+			return sel.size() == 1;
+		}));
 
 	QString enableAllActionName = QString::fromStdString("Enable All Breakpoints");
 	UIAction::registerAction(enableAllActionName);
@@ -510,7 +546,7 @@ void DebugBreakpointsWidget::soloSelected()
 
 	// Get the selected breakpoint location
 	BreakpointItem selectedBp = m_model->getRow(sel[0].row());
-	
+
 	// Disable all breakpoints first
 	std::vector<DebugBreakpoint> breakpoints = m_controller->GetBreakpoints();
 	for (const DebugBreakpoint& bp : breakpoints)
@@ -520,9 +556,31 @@ void DebugBreakpointsWidget::soloSelected()
 		info.offset = bp.offset;
 		m_controller->DisableBreakpoint(info);
 	}
-	
+
 	// Enable the selected breakpoint
 	m_controller->EnableBreakpoint(selectedBp.location());
+}
+
+
+void DebugBreakpointsWidget::editCondition()
+{
+	QModelIndexList sel = selectionModel()->selectedRows();
+	if (sel.size() != 1)
+		return;
+
+	BreakpointItem bp = m_model->getRow(sel[0].row());
+	std::string currentCondition = m_controller->GetBreakpointCondition(bp.location());
+
+	bool ok;
+	QString newCondition = QInputDialog::getText(
+		this, "Edit Condition", "Condition (e.g., $rax == 0x1234):",
+		QLineEdit::Normal, QString::fromStdString(currentCondition), &ok);
+
+	if (ok)
+	{
+		m_controller->SetBreakpointCondition(bp.location(), newCondition.trimmed().toStdString());
+		updateContent();
+	}
 }
 
 
@@ -554,7 +612,7 @@ void DebugBreakpointsWidget::updateContent()
 		ModuleNameAndOffset info;
 		info.module = bp.module;
 		info.offset = bp.offset;
-		bps.emplace_back(bp.enabled, info, bp.address);
+		bps.emplace_back(bp.enabled, info, bp.address, bp.condition);
 	}
 
 	m_model->updateRows(bps);
@@ -562,4 +620,5 @@ void DebugBreakpointsWidget::updateContent()
 	resizeColumnToContents(DebugBreakpointsListModel::EnabledColumn);
 	resizeColumnToContents(DebugBreakpointsListModel::LocationColumn);
 	resizeColumnToContents(DebugBreakpointsListModel::AddressColumn);
+	resizeColumnToContents(DebugBreakpointsListModel::ConditionColumn);
 }

--- a/ui/breakpointswidget.cpp
+++ b/ui/breakpointswidget.cpp
@@ -40,8 +40,10 @@ BreakpointItem::BreakpointItem(bool enabled, const ModuleNameAndOffset location,
 
 bool BreakpointItem::operator==(const BreakpointItem& other) const
 {
-	// Condition is not part of identity - same location = same breakpoint
-	return (m_enabled == other.enabled()) && (m_location == other.location()) && (m_address == other.address());
+	// While we shouldn't technically have breakpoints at the same address with different
+	// enabled status and/or condition, we compare all fields for completeness.
+	return (m_enabled == other.enabled()) && (m_location == other.location())
+		&& (m_address == other.address()) && (m_condition == other.condition());
 }
 
 
@@ -53,15 +55,13 @@ bool BreakpointItem::operator!=(const BreakpointItem& other) const
 
 bool BreakpointItem::operator<(const BreakpointItem& other) const
 {
-	if (m_enabled < other.enabled())
-		return true;
-	else if (m_enabled > other.enabled())
-		return false;
-	else if (m_location < other.location())
-		return true;
-	else if (m_location > other.location())
-		return false;
-	return m_address < other.address();
+	if (m_enabled != other.enabled())
+		return m_enabled < other.enabled();
+	if (m_location != other.location())
+		return m_location < other.location();
+	if (m_address != other.address())
+		return m_address < other.address();
+	return m_condition < other.condition();
 }
 
 

--- a/ui/breakpointswidget.h
+++ b/ui/breakpointswidget.h
@@ -39,12 +39,14 @@ private:
 	bool m_enabled;
 	ModuleNameAndOffset m_location;
 	uint64_t m_address;
+	std::string m_condition;
 
 public:
-	BreakpointItem(bool enabled, const ModuleNameAndOffset location, uint64_t remoteAddress);
+	BreakpointItem(bool enabled, const ModuleNameAndOffset location, uint64_t remoteAddress, const std::string& condition = "");
 	bool enabled() const { return m_enabled; }
 	ModuleNameAndOffset location() const { return m_location; }
 	uint64_t address() const { return m_address; }
+	std::string condition() const { return m_condition; }
 	bool operator==(const BreakpointItem& other) const;
 	bool operator!=(const BreakpointItem& other) const;
 	bool operator<(const BreakpointItem& other) const;
@@ -68,6 +70,7 @@ public:
 		EnabledColumn,
 		LocationColumn,
 		AddressColumn,
+		ConditionColumn,
 	};
 
 	DebugBreakpointsListModel(QWidget* parent, ViewFrame* view);
@@ -83,7 +86,7 @@ public:
 	virtual int columnCount(const QModelIndex& parent = QModelIndex()) const override
 	{
 		(void)parent;
-		return 3;
+		return 4;
 	}
 	BreakpointItem getRow(int row) const;
 	virtual QVariant data(const QModelIndex& i, int role) const override;
@@ -153,6 +156,7 @@ private slots:
 	void enableAll();
 	void disableAll();
 	void soloSelected();
+	void editCondition();
 
 public slots:
 	void updateContent();

--- a/ui/breakpointswidget.h
+++ b/ui/breakpointswidget.h
@@ -144,7 +144,6 @@ public:
 	DebugBreakpointsWidget(ViewFrame* view, BinaryViewRef data, Menu* menu);
 	~DebugBreakpointsWidget();
 
-	void uiEventHandler(const DebuggerEvent& event);
 	void updateFonts();
 
 private slots:

--- a/ui/debuggerwidget.cpp
+++ b/ui/debuggerwidget.cpp
@@ -135,6 +135,8 @@ void DebuggerWidget::uiEventHandler(const DebuggerEvent& event)
 	case RelativeBreakpointEnabledEvent:
 	case AbsoluteBreakpointDisabledEvent:
 	case RelativeBreakpointDisabledEvent:
+	case AbsoluteBreakpointConditionChangedEvent:
+	case RelativeBreakpointConditionChangedEvent:
 		m_breakpointsWidget->updateContent();
 		break;
 	default:

--- a/ui/ui.cpp
+++ b/ui/ui.cpp
@@ -1788,6 +1788,8 @@ void DebuggerUI::updateUI(const DebuggerEvent& event)
 	case AbsoluteBreakpointEnabledEvent:
 	case RelativeBreakpointDisabledEvent:
 	case AbsoluteBreakpointDisabledEvent:
+	case AbsoluteBreakpointConditionChangedEvent:
+	case RelativeBreakpointConditionChangedEvent:
 	{
 		m_context->refreshCurrentViewContents();
 		break;

--- a/ui/ui.cpp
+++ b/ui/ui.cpp
@@ -118,6 +118,36 @@ static void BreakpointToggleCallback(BinaryView* view, uint64_t addr)
 	}
 }
 
+static void BreakpointEditConditionCallback(BinaryView* view, uint64_t addr, UIContext* context)
+{
+	auto controller = DebuggerController::GetController(view);
+	if (!controller)
+		return;
+
+	const bool isAbsoluteAddress = controller->IsConnected();
+	const ModuleNameAndOffset relativeAddr = {
+		controller->GetInputFile(),
+		addr - controller->GetViewFileSegmentsStart()
+	};
+
+	const std::string currentCondition = isAbsoluteAddress
+		? controller->GetBreakpointCondition(addr)
+		: controller->GetBreakpointCondition(relativeAddr);
+
+	bool ok;
+	QString newCondition = QInputDialog::getText(
+		context->mainWindow(), "Edit Condition", "Condition (e.g., $rax == 0x1234):",
+		QLineEdit::Normal, QString::fromStdString(currentCondition), &ok);
+
+	if (ok)
+	{
+		if (isAbsoluteAddress)
+			controller->SetBreakpointCondition(addr, newCondition.trimmed().toStdString());
+		else
+			controller->SetBreakpointCondition(relativeAddr, newCondition.trimmed().toStdString());
+	}
+}
+
 static void JumpToIPCallback(BinaryView* view, UIContext* context)
 {
 	auto controller = DebuggerController::GetController(view);
@@ -926,6 +956,24 @@ void GlobalDebuggerUI::SetupMenu(UIContext* context)
 				return ctxt.binaryView && hasBreakpoint;
 			}));
 	debuggerMenu->addAction("Solo Breakpoint", "Breakpoint");
+
+	UIAction::registerAction("Edit Condition...");
+	context->globalActions()->bindAction("Edit Condition...",
+		UIAction(
+			[=](const UIActionContext& ctxt) {
+				if (!ctxt.binaryView || !ctxt.context)
+					return;
+				auto controller = DebuggerController::GetController(ctxt.binaryView);
+				if (!controller)
+					return;
+
+				BreakpointEditConditionCallback(ctxt.binaryView, ctxt.address, ctxt.context);
+			},
+			[=](const UIActionContext& ctxt) {
+				auto [hasBreakpoint, isEnabled] = getBreakpointEnabledState(ctxt.binaryView, ctxt.address);
+				return ctxt.binaryView && hasBreakpoint;
+			}));
+	debuggerMenu->addAction("Edit Condition...", "Breakpoint");
 
 	UIAction::registerAction("Connect to Debug Server");
 	context->globalActions()->bindAction("Connect to Debug Server",

--- a/ui/uinotification.cpp
+++ b/ui/uinotification.cpp
@@ -178,6 +178,7 @@ void NotificationListener::OnContextMenuCreated(UIContext *context, View* view, 
 	menu.addAction("Debugger", "Toggle Breakpoint", "Breakpoint");
 	menu.addAction("Debugger", "Enable Breakpoint", "Breakpoint");
 	menu.addAction("Debugger", "Solo Breakpoint", "Breakpoint");
+	menu.addAction("Debugger", "Edit Condition...", "Breakpoint");
 	menu.addAction("Debugger", "Launch", "Control");
 	menu.addAction("Debugger", "Pause", "Control");
 	menu.addAction("Debugger", "Restart", "Control");


### PR DESCRIPTION
## PR Overview

This PR adds conditional breakpoint support to the debugger, allowing a user to specify expressions that must evaluate to true for the breakpoint to actually trigger. This is implemented at the debugger core level (not adapter level), so it works the same across all adapters.

As discussed with @xusheng6:

The conditions for breakpoints are written using the expression parser (i.e. `$rax == 0`) making it the exact same for each debugger. The API now has:

- C++: `SetBreakpointCondition()`, `GetBreakpointCondition()` on DebuggerController
- Python: `set_breakpoint_condition()`, `get_breakpoint_condition()`

For example:
```cpp
controller->SetBreakpointCondition(address, "$rax == 0");
std::string cond = controller->GetBreakpointCondition(address);
```

```python
controller.set_breakpoint_condition(addr, "$rbx > 100")
cond = controller.get_breakpoint_condition(addr)
```


In the breakpoint widget, there's a new "Condition" column that can be set by right-clicking and pressing "Edit Condition...", this works in the widget and disassembly view.

<img width="812" height="578" alt="image" src="https://github.com/user-attachments/assets/63653231-5d93-400d-807e-9abb87661414" />

The condition is also persistent across sessions (saved to the binary view metadata).

## Upcoming Changes
- ~~Condition validation on the input dialog; the idea being to stop users from entering invalid expressions~~ (this is tricky to add due to the way the expression parser works, not going to do this)
- Possibility of adding hit counts, e.g., break after N hits
- ~~It makes sense to have some sort of unit testing for this. I reviewed the unit testing and noticed how breakpoints get tested in `debugger_test.py`, it would be trivial to add a quick unit test for conditions.~~
- Adding callbacks for conditional breakpoints being hit (#422). That may be out of scope for this PR albeit and @xusheng6 will need to advise.

This PR will close #93 and maybe close #422 (if the feature above is approved to be added in this PR).