### PR TITLE
Fix conditional breakpoint evaluation when stepping onto breakpoint

### DIFF
--- a/core/debuggercontroller.cpp
+++ b/core/debuggercontroller.cpp
@@ -2014,7 +2014,15 @@ void DebuggerController::DebuggerMainThread()
 			AddRegisterValuesToExpressionParser();
 			AddModuleValuesToExpressionParser();
 
-			if (uint64_t ip = m_state->IP(); m_state->GetBreakpoints()->ContainsAbsolute(ip))
+			bool isStepOperation = (m_lastOperation == DebugAdapterStepInto)
+				|| (m_lastOperation == DebugAdapterStepOver)
+				|| (m_lastOperation == DebugAdapterStepReturn)
+				|| (m_lastOperation == DebugAdapterStepIntoReverse)
+				|| (m_lastOperation == DebugAdapterStepOverReverse)
+				|| (m_lastOperation == DebugAdapterStepReturnReverse);
+
+			if (uint64_t ip = m_state->IP();
+				!isStepOperation && m_state->GetBreakpoints()->ContainsAbsolute(ip))
 			{
 				if (!EvaluateBreakpointCondition(ip))
 				{
@@ -2653,6 +2661,8 @@ DebugStopReason DebuggerController::ExecuteAdapterAndWait(const DebugAdapterOper
 			m_lastAdapterStopEventConsumed = true;
 		},
 		"WaitForAdapterStop");
+
+	m_lastOperation = operation;
 
 	bool resumeOK = false;
 	bool operationRequested = false;

--- a/core/debuggercontroller.cpp
+++ b/core/debuggercontroller.cpp
@@ -2014,6 +2014,8 @@ void DebuggerController::DebuggerMainThread()
 			AddRegisterValuesToExpressionParser();
 			AddModuleValuesToExpressionParser();
 
+			// skip conditional breakpoint evaluation for step operations - when the user explicitly
+			// steps onto a breakpoint, they expect to stop there regardless of the condition.
 			bool isStepOperation = (m_lastOperation == DebugAdapterStepInto)
 				|| (m_lastOperation == DebugAdapterStepOver)
 				|| (m_lastOperation == DebugAdapterStepReturn)

--- a/core/debuggercontroller.h
+++ b/core/debuggercontroller.h
@@ -114,6 +114,7 @@ namespace BinaryNinjaDebugger {
 		uint32_t m_exitCode = 0;
 
 		bool m_userRequestedBreak = false;
+		DebugAdapterOperation m_lastOperation = DebugAdapterGo;
 
 		bool m_lastAdapterStopEventConsumed = true;
 


### PR DESCRIPTION
@xusheng6 identified that LLDB will incorrectly report the stop reason as `Breakpoint` instead of `SingleStep` when stepping onto an instruction that has a breakpoint set. This caused conditional breakpoints to evaluate their condition even when the user explicitly stepped to that location which continues execution unexpectedly. https://github.com/Vector35/debugger/issues/941#issuecomment-3692548002

This fix tracks the last adapter operation and skips condition evaluation when the operation was a step (StepInto, StepOver, StepReturn, or their other variants). Condition evaluation now happens only when hitting breakpoints during Go/Continue operations.