### PR TITLE
add container file detection and extraction (and small cast issue)

### DIFF
--- a/core/adapters/dbgengadapter.cpp
+++ b/core/adapters/dbgengadapter.cpp
@@ -590,8 +590,8 @@ bool DbgEngAdapter::ExecuteWithArgsInternal(const std::string& path, const std::
 		this->Reset();
 		DebuggerEvent event;
 		event.type = LaunchFailureEventType;
-		event.data.errorData.error = fmt::format("CreateProcess2 failed: 0x{:x}", result);
-		event.data.errorData.shortError = fmt::format("CreateProcess2 failed: 0x{:x}", result);
+		event.data.errorData.error = fmt::format("CreateProcess2 failed: 0x{:08x}", (uint32_t)result);
+		event.data.errorData.shortError = fmt::format("CreateProcess2 failed: 0x{:08x}", (uint32_t)result);
 		PostDebuggerEvent(event);
 		return false;
 	}

--- a/ui/controlswidget.cpp
+++ b/ui/controlswidget.cpp
@@ -28,6 +28,9 @@ limitations under the License.
 #include <thread>
 #include "progresstask.h"
 #include "attachprocess.h"
+#include <filesystem>
+#include <fstream>
+#include <QFileDialog>
 
 using namespace BinaryNinjaDebuggerAPI;
 using namespace BinaryNinja;
@@ -168,8 +171,86 @@ QString DebugControlsWidget::getToolTip(const QString& name)
 }
 
 
+static bool extractBinaryToFile(BinaryViewRef data, const std::string& outputPath)
+{
+	BinaryViewRef rawView = data->GetParentView();
+	if (!rawView)
+		rawView = data;
+
+	uint64_t length = rawView->GetLength();
+	DataBuffer buffer = rawView->ReadBuffer(0, length);
+	if (buffer.GetLength() != length)
+		return false;
+
+	std::ofstream file(outputPath, std::ios::binary);
+	if (!file)
+		return false;
+
+	file.write(reinterpret_cast<const char*>(buffer.GetData()), buffer.GetLength());
+	return file.good();
+}
+
+
+bool DebugControlsWidget::handleContainerFile()
+{
+	namespace fs = std::filesystem;
+
+	auto data = m_controller->GetData();
+	auto file = data->GetFile();
+
+	std::string execPath = m_controller->GetExecutablePath();
+	if (!execPath.empty() && fs::exists(execPath))
+		return true;
+
+	std::string currentPath = file->GetFilename();
+	std::string originalPath = file->GetOriginalFilename();
+
+	bool isBndb = currentPath.ends_with(".bndb") && currentPath != originalPath;
+	bool isVirtualPath = currentPath.find("::") != std::string::npos;
+	bool isVirtualFile = !fs::path(originalPath).is_absolute();
+
+	if (!isBndb && !isVirtualPath && !isVirtualFile)
+		return true;
+
+	if (fs::exists(originalPath))
+		return true;
+
+	auto prompt = QString(
+		"The debugger requires the executable file on disk to launch.\n\n"
+		"Original file: %1\n\n"
+		"This file does not exist. Would you like to extract it?")
+		.arg(QString::fromStdString(originalPath));
+
+	if (QMessageBox::question(this, "File Not Found", prompt) != QMessageBox::Yes)
+		return false;
+
+	fs::path defaultPath = fs::current_path() / fs::path(originalPath).filename();
+	if (isBndb)
+		defaultPath = fs::path(currentPath).parent_path() / fs::path(originalPath).filename();
+
+	QString extractPath = QFileDialog::getSaveFileName(
+		this, "Extract Binary", QString::fromStdString(defaultPath.string()), "All Files (*)");
+
+	if (extractPath.isEmpty())
+		return false;
+
+	if (!extractBinaryToFile(data, extractPath.toStdString()))
+	{
+		QMessageBox::critical(this, "Extraction Failed",
+			"Failed to extract the binary. See logs for details.");
+		return false;
+	}
+
+	m_controller->SetExecutablePath(extractPath.toStdString());
+	return true;
+}
+
+
 void DebugControlsWidget::performLaunch()
 {
+	if (!handleContainerFile())
+		return;
+
 	bool firstLaunch = m_controller->IsFirstLaunch();
 	if (firstLaunch)
 	{

--- a/ui/controlswidget.cpp
+++ b/ui/controlswidget.cpp
@@ -212,6 +212,9 @@ bool DebugControlsWidget::handleContainerFile()
 	if (!isBndb && !isVirtualPath && !isVirtualFile)
 		return true;
 
+	if (fs::exists(originalPath))
+		return true;
+
 	auto prompt = QString(
 		"The debugger requires the executable file on disk to launch.\n\n"
 		"Original file: %1\n\n"
@@ -221,29 +224,9 @@ bool DebugControlsWidget::handleContainerFile()
 	if (QMessageBox::question(this, "File Not Found", prompt) != QMessageBox::Yes)
 		return false;
 
-	fs::path defaultPath;
+	fs::path defaultPath = fs::current_path() / fs::path(originalPath).filename();
 	if (isBndb)
-	{
 		defaultPath = fs::path(currentPath).parent_path() / fs::path(originalPath).filename();
-	}
-	else if (isVirtualPath)
-	{
-		size_t schemeEnd = currentPath.find("://");
-		size_t pathEnd = currentPath.find("::");
-		if (schemeEnd != std::string::npos && pathEnd != std::string::npos && pathEnd > schemeEnd + 3)
-		{
-			std::string containerPath = currentPath.substr(schemeEnd + 3, pathEnd - schemeEnd - 3);
-			defaultPath = fs::path(containerPath).parent_path() / fs::path(originalPath).filename();
-		}
-		else
-		{
-			defaultPath = fs::current_path() / fs::path(originalPath).filename();
-		}
-	}
-	else
-	{
-		defaultPath = fs::current_path() / fs::path(originalPath).filename();
-	}
 
 	QString extractPath = QFileDialog::getSaveFileName(
 		this, "Extract Binary", QString::fromStdString(defaultPath.string()), "All Files (*)");

--- a/ui/controlswidget.cpp
+++ b/ui/controlswidget.cpp
@@ -212,6 +212,10 @@ bool DebugControlsWidget::handleContainerFile()
 	if (!isBndb && !isVirtualPath && !isVirtualFile)
 		return true;
 
+	// If the user is debugging without opening a file, we do not want to show the dialog
+	if (originalPath.empty())
+		return true;
+
 	if (fs::exists(originalPath))
 		return true;
 

--- a/ui/controlswidget.cpp
+++ b/ui/controlswidget.cpp
@@ -205,14 +205,11 @@ bool DebugControlsWidget::handleContainerFile()
 	std::string currentPath = file->GetFilename();
 	std::string originalPath = file->GetOriginalFilename();
 
-	bool isBndb = currentPath.ends_with(".bndb") && currentPath != originalPath;
+	bool isBndb = file->IsBackedByDatabase();
 	bool isVirtualPath = currentPath.find("::") != std::string::npos;
 	bool isVirtualFile = !fs::path(originalPath).is_absolute();
 
 	if (!isBndb && !isVirtualPath && !isVirtualFile)
-		return true;
-
-	if (fs::exists(originalPath))
 		return true;
 
 	auto prompt = QString(
@@ -224,9 +221,29 @@ bool DebugControlsWidget::handleContainerFile()
 	if (QMessageBox::question(this, "File Not Found", prompt) != QMessageBox::Yes)
 		return false;
 
-	fs::path defaultPath = fs::current_path() / fs::path(originalPath).filename();
+	fs::path defaultPath;
 	if (isBndb)
+	{
 		defaultPath = fs::path(currentPath).parent_path() / fs::path(originalPath).filename();
+	}
+	else if (isVirtualPath)
+	{
+		size_t schemeEnd = currentPath.find("://");
+		size_t pathEnd = currentPath.find("::");
+		if (schemeEnd != std::string::npos && pathEnd != std::string::npos && pathEnd > schemeEnd + 3)
+		{
+			std::string containerPath = currentPath.substr(schemeEnd + 3, pathEnd - schemeEnd - 3);
+			defaultPath = fs::path(containerPath).parent_path() / fs::path(originalPath).filename();
+		}
+		else
+		{
+			defaultPath = fs::current_path() / fs::path(originalPath).filename();
+		}
+	}
+	else
+	{
+		defaultPath = fs::current_path() / fs::path(originalPath).filename();
+	}
 
 	QString extractPath = QFileDialog::getSaveFileName(
 		this, "Extract Binary", QString::fromStdString(defaultPath.string()), "All Files (*)");

--- a/ui/controlswidget.h
+++ b/ui/controlswidget.h
@@ -57,6 +57,7 @@ private:
 
 	bool canExec();
 	bool canConnect();
+	bool handleContainerFile();
 
 	QIcon getColoredIcon(const QString& iconPath, const QColor& color);
 	QString getToolTip(const QString& name);


### PR DESCRIPTION
Adds automated detection of container files (BNDB, zip archives, virtual paths) at debug launch time, and if the original file is missing for them on the disk, prompts the user to automatically extract the binary to the disk. This makes the flow a lot nicer!

When reproducing the issue I realised the `CreateProcess2 failed: 0x..` error code was wrong because they were signed `HSRESULT` values, now they are casted to `uint32_t`.

This PR will close #925 