### PR TITLE
Add nullptr checks for dynamically acquired UI objects

### DIFF
--- a/ui/breakpointswidget.cpp
+++ b/ui/breakpointswidget.cpp
@@ -454,7 +454,13 @@ void DebugBreakpointsWidget::jump()
 
 	BreakpointItem bp = m_model->getRow(sel[0].row());
 	UIContext* context = UIContext::contextForWidget(this);
+	if (!context)
+		return;
+
 	ViewFrame* frame = context->getCurrentViewFrame();
+	if (!frame)
+		return;
+
 	if (m_controller->GetData())
 		frame->navigate(m_controller->GetData(), bp.address(), true, true);
 }

--- a/ui/controlswidget.cpp
+++ b/ui/controlswidget.cpp
@@ -422,7 +422,14 @@ void DebugControlsWidget::performSettings()
 void DebugControlsWidget::toggleBreakpoint()
 {
 	UIContext* context = UIContext::contextForWidget(this);
-	auto addr = context->getCurrentView()->getCurrentOffset();
+	if (!context)
+		return;
+
+	View* view = context->getCurrentView();
+	if (!view)
+		return;
+
+	auto addr = view->getCurrentOffset();
 	bool isAbsoluteAddress = false;
 	if (m_controller->IsConnected())
 		isAbsoluteAddress = true;

--- a/ui/ui.cpp
+++ b/ui/ui.cpp
@@ -1542,7 +1542,13 @@ void GlobalDebuggerUI::CloseGlobalAreaWidgets(UIContext* context)
 void DebuggerUI::navigateDebugger(uint64_t address)
 {
 	ViewFrame* frame = m_context->getCurrentViewFrame();
+	if (!frame)
+		return;
+
 	View* view = m_context->getCurrentView();
+	if (!view)
+		return;
+
 	FunctionRef function = view->getCurrentFunction();
 	if (function)
 	{
@@ -1663,8 +1669,13 @@ void DebuggerUI::navigateToMappedAddress()
 void DebuggerUI::checkRebaseBinaryView(uint64_t remoteBase)
 {
 	Ref<BinaryView> data = m_controller->GetData();
+	if (!data)
+		return;
+
 	FileMetadataRef fileMetadata = data->GetFile();
 	ViewFrame* frame = m_context->getCurrentViewFrame();
+	if (!frame)
+		return;
 
 	// Halt analysis when replacing a BinaryView in the UI. If the view is replaced and the tab or
 	// application closes, then the old view may continue analysis without the updated UI having a


### PR DESCRIPTION
This PR adds nullptr checks for dynamically acquired objects `UIContext`, `ViewFrame`, `View` and `BinaryView`.  This will prevent crashes when UI state changes during something like closing a tab as an event happens.

This PR closes #722