### PR TITLE
Add TTD attach to running process support

### DIFF
--- a/api/debuggerapi.h
+++ b/api/debuggerapi.h
@@ -278,12 +278,16 @@ namespace BinaryNinjaDebuggerAPI {
 	{
 		std::uint32_t m_pid {};
 		std::string m_processName {};
+		std::string m_commandLine {};
 
 		DebugProcess() {}
 
 		DebugProcess(std::uint32_t pid) : m_pid(pid) {}
 
 		DebugProcess(std::uint32_t pid, std::string name) : m_pid(pid), m_processName(name) {}
+
+		DebugProcess(std::uint32_t pid, std::string name, std::string commandLine) :
+			m_pid(pid), m_processName(name), m_commandLine(commandLine) {}
 
 		bool operator==(const DebugProcess& rhs) const
 		{

--- a/api/debuggercontroller.cpp
+++ b/api/debuggercontroller.cpp
@@ -159,6 +159,7 @@ std::vector<DebugProcess> DebuggerController::GetProcessList()
 		DebugProcess process;
 		process.m_pid = processes[i].m_pid;
 		process.m_processName = processes[i].m_processName;
+		process.m_commandLine = processes[i].m_commandLine;
 		result.push_back(process);
 	}
 	BNDebuggerFreeProcessList(processes, count);

--- a/api/ffi.h
+++ b/api/ffi.h
@@ -84,6 +84,7 @@ extern "C"
 	{
 		uint32_t m_pid;
 		char* m_processName;
+		char* m_commandLine;
 	} BNDebugProcess;
 
 	typedef struct BNDebugThread

--- a/api/python/debuggercontroller.py
+++ b/api/python/debuggercontroller.py
@@ -62,12 +62,14 @@ class DebugProcess:
 
     * ``pid``: the ID of the process
     * ``name``: the name of the process
+    * ``command_line``: the command line of the process
 
     """
 
-    def __init__(self, pid, name):
+    def __init__(self, pid, name, command_line=""):
         self.pid = pid
         self.name = name
+        self.command_line = command_line
 
     def __eq__(self, other):
         if not isinstance(other, self.__class__):
@@ -1284,7 +1286,7 @@ class DebuggerController:
         process_list = dbgcore.BNDebuggerGetProcessList(self.handle, count)
         result = []
         for i in range(0, count.value):
-            process = DebugProcess(process_list[i].m_pid, process_list[i].m_processName)
+            process = DebugProcess(process_list[i].m_pid, process_list[i].m_processName, process_list[i].m_commandLine)
             result.append(process)
 
         dbgcore.BNDebuggerFreeProcessList(process_list, count.value)

--- a/core/adapters/dbgengadapter.cpp
+++ b/core/adapters/dbgengadapter.cpp
@@ -27,6 +27,8 @@ limitations under the License.
 #include <filesystem>
 #ifdef _WIN32
 #include <shellapi.h>
+#include <TlHelp32.h>
+#include <winternl.h>
 #endif
 #include "dbgengadapter.h"
 #include "../../cli/log.h"
@@ -887,10 +889,142 @@ bool DbgEngAdapter::Quit()
 	return true;
 }
 
+// Function pointer type for NtQueryInformationProcess
+typedef NTSTATUS (NTAPI *NtQueryInformationProcessFn)(
+	HANDLE ProcessHandle,
+	PROCESSINFOCLASS ProcessInformationClass,
+	PVOID ProcessInformation,
+	ULONG ProcessInformationLength,
+	PULONG ReturnLength
+);
+
+
+static std::string GetProcessCommandLine(DWORD pid)
+{
+	std::string result;
+
+	// Can't get command line for system processes
+	if (pid == 0 || pid == 4)
+		return result;
+
+	HANDLE hProcess = OpenProcess(PROCESS_QUERY_INFORMATION | PROCESS_VM_READ, FALSE, pid);
+	if (!hProcess)
+		return result;
+
+	// Get NtQueryInformationProcess from ntdll
+	static NtQueryInformationProcessFn NtQueryInformationProcess = nullptr;
+	if (!NtQueryInformationProcess)
+	{
+		HMODULE ntdll = GetModuleHandleW(L"ntdll.dll");
+		if (ntdll)
+			NtQueryInformationProcess = (NtQueryInformationProcessFn)GetProcAddress(ntdll, "NtQueryInformationProcess");
+	}
+
+	if (!NtQueryInformationProcess)
+	{
+		CloseHandle(hProcess);
+		return result;
+	}
+
+	// Get the PEB address
+	PROCESS_BASIC_INFORMATION pbi;
+	ULONG returnLength;
+	NTSTATUS status = NtQueryInformationProcess(hProcess, ProcessBasicInformation, &pbi, sizeof(pbi), &returnLength);
+	if (status != 0)
+	{
+		CloseHandle(hProcess);
+		return result;
+	}
+
+	// Read the PEB to get the process parameters address
+	// Use the standard PEB structure from winternl.h
+	PEB peb;
+	SIZE_T bytesRead;
+	if (!ReadProcessMemory(hProcess, pbi.PebBaseAddress, &peb, sizeof(peb), &bytesRead))
+	{
+		CloseHandle(hProcess);
+		return result;
+	}
+
+	// Read the RTL_USER_PROCESS_PARAMETERS
+	// Use the standard RTL_USER_PROCESS_PARAMETERS structure from winternl.h
+	RTL_USER_PROCESS_PARAMETERS params;
+	if (!ReadProcessMemory(hProcess, peb.ProcessParameters, &params, sizeof(params), &bytesRead))
+	{
+		CloseHandle(hProcess);
+		return result;
+	}
+
+	// Read the command line string
+	if (params.CommandLine.Length > 0 && params.CommandLine.Buffer)
+	{
+		std::wstring cmdLine(params.CommandLine.Length / sizeof(WCHAR), L'\0');
+		if (ReadProcessMemory(hProcess, params.CommandLine.Buffer, &cmdLine[0], params.CommandLine.Length, &bytesRead))
+		{
+			// Convert wide string to UTF-8
+			int size = WideCharToMultiByte(CP_UTF8, 0, cmdLine.c_str(), -1, nullptr, 0, nullptr, nullptr);
+			if (size > 0)
+			{
+				result.resize(size - 1);
+				WideCharToMultiByte(CP_UTF8, 0, cmdLine.c_str(), -1, &result[0], size, nullptr, nullptr);
+			}
+		}
+	}
+
+	CloseHandle(hProcess);
+	return result;
+}
+
+
 std::vector<DebugProcess> DbgEngAdapter::GetProcessList()
 {
+	// For local debugging (not connected to remote debug server), use Windows APIs directly to get command lines
+	if (!m_connectedToDebugServer)
+	{
+		std::vector<DebugProcess> result;
+		HANDLE snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
+		if (snapshot == INVALID_HANDLE_VALUE)
+			return result;
+
+		PROCESSENTRY32W entry;
+		entry.dwSize = sizeof(entry);
+
+		if (Process32FirstW(snapshot, &entry))
+		{
+			do
+			{
+				DWORD pid = entry.th32ProcessID;
+				std::string processName;
+
+				// Convert wide string to narrow string for process name
+				int size = WideCharToMultiByte(CP_UTF8, 0, entry.szExeFile, -1, nullptr, 0, nullptr, nullptr);
+				if (size > 0)
+				{
+					processName.resize(size - 1);
+					WideCharToMultiByte(CP_UTF8, 0, entry.szExeFile, -1, &processName[0], size, nullptr, nullptr);
+				}
+
+				// Get command line for the process
+				std::string commandLine;
+				try
+				{
+					commandLine = GetProcessCommandLine(pid);
+				}
+				catch (...)
+				{
+					// Ignore errors getting command line
+				}
+
+				result.emplace_back(pid, processName, commandLine);
+			} while (Process32NextW(snapshot, &entry));
+		}
+
+		CloseHandle(snapshot);
+		return result;
+	}
+
+	// For remote debugging, use DbgEng APIs (no command line available)
 	// we need to start dbgserver in order to get process list
-	
 	if (!m_dbgengInitialized)
 	{
 		if (!Start())
@@ -918,18 +1052,18 @@ std::vector<DebugProcess> DbgEngAdapter::GetProcessList()
 		ZeroMemory(processName, MAX_PATH);
 
 		if (m_debugClient->GetRunningProcessDescription(
-			m_server, 
-			procIds[i], 
-			DEBUG_PROC_DESC_DEFAULT, 
+			m_server,
+			procIds[i],
+			DEBUG_PROC_DESC_DEFAULT,
 			processName,
-			sizeof(processName), 
-			NULL, 
-			NULL, 
-			0, 
+			sizeof(processName),
+			NULL,
+			NULL,
+			0,
 			NULL) != S_OK)
 		{
 			strcpy_s(processName, MAX_PATH, "<could not get process name>");
-		}	
+		}
 
 		debug_processes.emplace_back(procIds[i], processName);
 	}

--- a/core/debugadapter.h
+++ b/core/debugadapter.h
@@ -79,12 +79,16 @@ namespace BinaryNinjaDebugger {
 	{
 		std::uint32_t m_pid {};
 		std::string m_processName {};
+		std::string m_commandLine {};
 
 		DebugProcess() {}
 
 		DebugProcess(std::uint32_t pid) : m_pid(pid) {}
 
 		DebugProcess(std::uint32_t pid, std::string name) : m_pid(pid), m_processName(name) {}
+
+		DebugProcess(std::uint32_t pid, std::string name, std::string commandLine) :
+			m_pid(pid), m_processName(name), m_commandLine(commandLine) {}
 
 		bool operator==(const DebugProcess& rhs) const
 		{

--- a/core/ffi.cpp
+++ b/core/ffi.cpp
@@ -192,6 +192,7 @@ BNDebugProcess* BNDebuggerGetProcessList(BNDebuggerController* controller, size_
 	{
 		results[i].m_pid = processes[i].m_pid;
 		results[i].m_processName = BNDebuggerAllocString(processes[i].m_processName.c_str());
+		results[i].m_commandLine = BNDebuggerAllocString(processes[i].m_commandLine.c_str());
 	}
 
 	return results;
@@ -203,6 +204,7 @@ void BNDebuggerFreeProcessList(BNDebugProcess* processes, size_t count)
 	for (size_t i = 0; i < count; i++)
 	{
 		BNDebuggerFreeString(processes[i].m_processName);
+		BNDebuggerFreeString(processes[i].m_commandLine);
 	}
 
 	delete[] processes;

--- a/ui/attachprocess.cpp
+++ b/ui/attachprocess.cpp
@@ -23,7 +23,8 @@ using namespace std;
 
 constexpr int SortFilterRole = Qt::UserRole + 1;
 
-ProcessItem::ProcessItem(uint32_t pid, std::string processName) : m_pid(pid), m_processName(processName) {}
+ProcessItem::ProcessItem(uint32_t pid, std::string processName, std::string commandLine) :
+	m_pid(pid), m_processName(processName), m_commandLine(commandLine) {}
 
 
 bool ProcessItem::operator==(const ProcessItem& other) const
@@ -104,6 +105,14 @@ QVariant ProcessListModel::data(const QModelIndex& index, int role) const
 
 		return QVariant(text);
 	}
+	case ProcessListModel::CommandLineColumn:
+	{
+		QString text = QString::fromStdString(item->commandLine());
+		if (role == Qt::SizeHintRole)
+			return QVariant((qulonglong)text.size());
+
+		return QVariant(text);
+	}
 	}
 	return QVariant();
 }
@@ -123,6 +132,8 @@ QVariant ProcessListModel::headerData(int column, Qt::Orientation orientation, i
 		return "PID";
 	case ProcessListModel::ProcessNameColumn:
 		return "Name";
+	case ProcessListModel::CommandLineColumn:
+		return "Command Line";
 	}
 	return QVariant();
 }
@@ -134,10 +145,18 @@ void ProcessListModel::updateRows(std::vector<DebugProcess> processList)
 
 	std::vector<ProcessItem> newProcessList;
 	for (const DebugProcess& process : processList)
-		newProcessList.emplace_back(process.m_pid, process.m_processName);
+		newProcessList.emplace_back(process.m_pid, process.m_processName, process.m_commandLine);
 
 	m_items = newProcessList;
 
+	endResetModel();
+}
+
+
+void ProcessListModel::updateRows(std::vector<ProcessItem> processList)
+{
+	beginResetModel();
+	m_items = std::move(processList);
 	endResetModel();
 }
 
@@ -170,6 +189,10 @@ void ProcessItemDelegate::paint(QPainter* painter, const QStyleOptionViewItem& o
 		painter->drawText(textRect, data.toString());
 		break;
 	case ProcessListModel::ProcessNameColumn:
+		painter->setPen(option.palette.color(QPalette::WindowText).rgba());
+		painter->drawText(textRect, data.toString());
+		break;
+	case ProcessListModel::CommandLineColumn:
 		painter->setPen(option.palette.color(QPalette::WindowText).rgba());
 		painter->drawText(textRect, data.toString());
 		break;
@@ -218,6 +241,13 @@ void ProcessListModel::sort(int col, Qt::SortOrder order)
 				return a.processName() < b.processName();
 			else
 				return a.processName() > b.processName();
+		}
+		else if (col == ProcessListModel::CommandLineColumn)
+		{
+			if (order == Qt::AscendingOrder)
+				return a.commandLine() < b.commandLine();
+			else
+				return a.commandLine() > b.commandLine();
 		}
 		return false;
 	});
@@ -309,12 +339,29 @@ void ProcessListWidget::updateColumnWidths()
 {
 	resizeColumnToContents(ProcessListModel::PidColumn);
 	resizeColumnToContents(ProcessListModel::ProcessNameColumn);
+	resizeColumnToContents(ProcessListModel::CommandLineColumn);
 }
 
 
 void ProcessListWidget::updateContent()
 {
-	std::vector<DebugProcess> processList = m_controller->GetProcessList();
+	std::vector<DebugProcess> processList;
+	if (m_controller)
+		processList = m_controller->GetProcessList();
+	m_model->updateRows(processList);
+	updateColumnWidths();
+}
+
+
+void ProcessListWidget::updateContent(const std::vector<DebugProcess>& processList)
+{
+	m_model->updateRows(processList);
+	updateColumnWidths();
+}
+
+
+void ProcessListWidget::updateContent(const std::vector<ProcessItem>& processList)
+{
 	m_model->updateRows(processList);
 	updateColumnWidths();
 }

--- a/ui/attachprocess.cpp
+++ b/ui/attachprocess.cpp
@@ -389,7 +389,7 @@ void ProcessListWidget::activateSelection() {}
 AttachProcessDialog::AttachProcessDialog(QWidget* parent, DbgRef<DebuggerController> controller) : QDialog(parent)
 {
 	setWindowTitle("Attach to process");
-	setMinimumSize(UIContext::getScaledWindowSize(450, 600));
+	setMinimumSize(UIContext::getScaledWindowSize(800, 600));
 	setSizeGripEnabled(true);
 	setModal(true);
 

--- a/ui/attachprocess.h
+++ b/ui/attachprocess.h
@@ -34,11 +34,13 @@ class ProcessItem
 private:
 	uint32_t m_pid;
 	std::string m_processName;
+	std::string m_commandLine;
 
 public:
-	ProcessItem(uint32_t pid, std::string processName);
+	ProcessItem(uint32_t pid, std::string processName, std::string commandLine = "");
 	uint32_t pid() const { return m_pid; }
 	std::string processName() const { return m_processName; }
+	std::string commandLine() const { return m_commandLine; }
 	bool operator==(const ProcessItem& other) const;
 	bool operator!=(const ProcessItem& other) const;
 	bool operator<(const ProcessItem& other) const;
@@ -59,6 +61,7 @@ public:
 	{
 		PidColumn,
 		ProcessNameColumn,
+		CommandLineColumn,
 	};
 
 	ProcessListModel(QWidget* parent);
@@ -74,14 +77,15 @@ public:
 	virtual int columnCount(const QModelIndex& parent = QModelIndex()) const override
 	{
 		(void)parent;
-		return 2;
+		return 3;
 	}
 	ProcessItem getRow(int row) const;
 	virtual QVariant data(const QModelIndex& i, int role) const override;
 	virtual QVariant headerData(int column, Qt::Orientation orientation, int role) const override;
 	virtual void sort(int col, Qt::SortOrder order) override;
-	
+
 	void updateRows(std::vector<DebugProcess> processList);
+	void updateRows(std::vector<ProcessItem> processList);
 };
 
 
@@ -138,6 +142,9 @@ class ProcessListWidget : public QTableView, public FilterTarget
 public:
 	ProcessListWidget(QWidget* parent, DbgRef<DebuggerController> controller);
 	~ProcessListWidget();
+
+	void updateContent(const std::vector<DebugProcess>& processList);
+	void updateContent(const std::vector<ProcessItem>& processList);
 
 	uint32_t GetSelectedPid()
 	{

--- a/ui/ttdrecord.cpp
+++ b/ui/ttdrecord.cpp
@@ -370,7 +370,7 @@ TTDAttachDialog::TTDAttachDialog(QWidget* parent, BinaryView* data) :
 
 	setWindowTitle("TTD Attach to Process");
 	setAttribute(Qt::WA_DeleteOnClose);
-	setMinimumSize(UIContext::getScaledWindowSize(500, 600));
+	setMinimumSize(UIContext::getScaledWindowSize(800, 600));
 	setSizeGripEnabled(true);
 	setModal(true);
 

--- a/ui/ttdrecord.cpp
+++ b/ui/ttdrecord.cpp
@@ -19,10 +19,134 @@ limitations under the License.
 #include "qfiledialog.h"
 #include "fmt/format.h"
 #include <QMessageBox>
+#include <TlHelp32.h>
+#include <winternl.h>
 
 using namespace BinaryNinjaDebuggerAPI;
 using namespace BinaryNinja;
 using namespace std;
+
+
+// Function pointer type for NtQueryInformationProcess
+typedef NTSTATUS (NTAPI *NtQueryInformationProcessFn)(
+	HANDLE ProcessHandle,
+	PROCESSINFOCLASS ProcessInformationClass,
+	PVOID ProcessInformation,
+	ULONG ProcessInformationLength,
+	PULONG ReturnLength
+);
+
+
+static std::string GetProcessCommandLine(DWORD pid)
+{
+	std::string result;
+
+	// Can't get command line for system processes
+	if (pid == 0 || pid == 4)
+		return result;
+
+	HANDLE hProcess = OpenProcess(PROCESS_QUERY_INFORMATION | PROCESS_VM_READ, FALSE, pid);
+	if (!hProcess)
+		return result;
+
+	// Get NtQueryInformationProcess from ntdll
+	static NtQueryInformationProcessFn NtQueryInformationProcess = nullptr;
+	if (!NtQueryInformationProcess)
+	{
+		HMODULE ntdll = GetModuleHandleW(L"ntdll.dll");
+		if (ntdll)
+			NtQueryInformationProcess = (NtQueryInformationProcessFn)GetProcAddress(ntdll, "NtQueryInformationProcess");
+	}
+
+	if (!NtQueryInformationProcess)
+	{
+		CloseHandle(hProcess);
+		return result;
+	}
+
+	// Get the PEB address
+	PROCESS_BASIC_INFORMATION pbi;
+	ULONG returnLength;
+	NTSTATUS status = NtQueryInformationProcess(hProcess, ProcessBasicInformation, &pbi, sizeof(pbi), &returnLength);
+	if (status != 0)
+	{
+		CloseHandle(hProcess);
+		return result;
+	}
+
+	// Read the PEB to get the process parameters address
+	PEB peb;
+	SIZE_T bytesRead;
+	if (!ReadProcessMemory(hProcess, pbi.PebBaseAddress, &peb, sizeof(peb), &bytesRead))
+	{
+		CloseHandle(hProcess);
+		return result;
+	}
+
+	// Read the RTL_USER_PROCESS_PARAMETERS
+	RTL_USER_PROCESS_PARAMETERS params;
+	if (!ReadProcessMemory(hProcess, peb.ProcessParameters, &params, sizeof(params), &bytesRead))
+	{
+		CloseHandle(hProcess);
+		return result;
+	}
+
+	// Read the command line string
+	if (params.CommandLine.Length > 0 && params.CommandLine.Buffer)
+	{
+		std::wstring cmdLine(params.CommandLine.Length / sizeof(WCHAR), L'\0');
+		if (ReadProcessMemory(hProcess, params.CommandLine.Buffer, &cmdLine[0], params.CommandLine.Length, &bytesRead))
+		{
+			// Convert wide string to UTF-8
+			int size = WideCharToMultiByte(CP_UTF8, 0, cmdLine.c_str(), -1, nullptr, 0, nullptr, nullptr);
+			if (size > 0)
+			{
+				result.resize(size - 1);
+				WideCharToMultiByte(CP_UTF8, 0, cmdLine.c_str(), -1, &result[0], size, nullptr, nullptr);
+			}
+		}
+	}
+
+	CloseHandle(hProcess);
+	return result;
+}
+
+
+static std::vector<ProcessItem> EnumerateProcessesWithCommandLine()
+{
+	std::vector<ProcessItem> result;
+	HANDLE snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
+	if (snapshot == INVALID_HANDLE_VALUE)
+		return result;
+
+	PROCESSENTRY32W entry;
+	entry.dwSize = sizeof(entry);
+
+	if (Process32FirstW(snapshot, &entry))
+	{
+		do
+		{
+			DWORD pid = entry.th32ProcessID;
+			std::string processName;
+
+			// Convert wide string to narrow string for process name
+			int size = WideCharToMultiByte(CP_UTF8, 0, entry.szExeFile, -1, nullptr, 0, nullptr, nullptr);
+			if (size > 0)
+			{
+				processName.resize(size - 1);
+				WideCharToMultiByte(CP_UTF8, 0, entry.szExeFile, -1, &processName[0], size, nullptr, nullptr);
+			}
+
+			// Get command line for the process
+			std::string commandLine = GetProcessCommandLine(pid);
+
+			result.emplace_back(pid, processName, commandLine);
+		} while (Process32NextW(snapshot, &entry));
+	}
+
+	CloseHandle(snapshot);
+	return result;
+}
 
 TTDRecordDialog::TTDRecordDialog(QWidget* parent, BinaryView* data) :
 	QDialog()
@@ -229,6 +353,150 @@ void TTDRecordDialog::DoTTDTrace()
 	if (ret == FALSE)
 	{
 		QMessageBox::critical(this, "Recording Failed", QString::asprintf("TTD recording failed: %lu", GetLastError()));
+		return;
+	}
+
+	LogDebug("info.hProcess: %d", info.hProcess);
+	WaitForSingleObject(info.hProcess, INFINITE);
+	QMessageBox::information(this, "Recording Completed", "The TTD recording has completed and you can now debug the trace");
+}
+
+
+TTDAttachDialog::TTDAttachDialog(QWidget* parent, BinaryView* data) :
+	QDialog()
+{
+	if (data)
+		m_controller = DebuggerController::GetController(data);
+
+	setWindowTitle("TTD Attach to Process");
+	setAttribute(Qt::WA_DeleteOnClose);
+	setMinimumSize(UIContext::getScaledWindowSize(500, 600));
+	setSizeGripEnabled(true);
+	setModal(true);
+
+	QVBoxLayout* layout = new QVBoxLayout;
+	layout->setSpacing(10);
+
+	// Process list section - pass nullptr to avoid using controller's GetProcessList
+	// We always want to use our own EnumerateProcessesWithCommandLine() for TTD
+	m_processListWidget = new ProcessListWidget(this, nullptr);
+	m_separateEdit = new FilterEdit(m_processListWidget);
+	m_filter = new FilteredView(this, m_processListWidget, m_processListWidget, m_separateEdit);
+	m_filter->setFilterPlaceholderText("Search process");
+
+	auto headerLayout = new QHBoxLayout();
+	headerLayout->addWidget(m_separateEdit, 1);
+
+	auto filterLayout = new QVBoxLayout();
+	filterLayout->setContentsMargins(0, 0, 0, 0);
+	filterLayout->addLayout(headerLayout);
+	filterLayout->addWidget(m_filter, 1);
+
+	// TTD options section
+	m_outputDirectory = new QLineEdit(this);
+	m_traceChildProcesses = new QCheckBox(this);
+
+	auto* outputDirSelector = new QPushButton("...", this);
+	outputDirSelector->setMaximumWidth(30);
+	connect(outputDirSelector, &QPushButton::clicked, [&]() {
+		auto pathName = QFileDialog::getExistingDirectory(this, "Specify Trace Output Directory",
+			m_outputDirectory->text(), QFileDialog::ShowDirsOnly | QFileDialog::DontResolveSymlinks);
+		if (!pathName.isEmpty())
+			m_outputDirectory->setText(pathName);
+	});
+
+	auto outputLayout = new QHBoxLayout;
+	outputLayout->addWidget(m_outputDirectory);
+	outputLayout->addWidget(outputDirSelector);
+
+	auto traceChildProcessesLayout = new QHBoxLayout;
+	traceChildProcessesLayout->addWidget(m_traceChildProcesses);
+	traceChildProcessesLayout->addWidget(new QLabel("Trace Child Processes"));
+	traceChildProcessesLayout->addStretch();
+
+	QVBoxLayout* optionsLayout = new QVBoxLayout;
+	optionsLayout->setSpacing(5);
+	optionsLayout->addWidget(new QLabel("Trace Output Directory"));
+	optionsLayout->addLayout(outputLayout);
+	optionsLayout->addLayout(traceChildProcessesLayout);
+
+	// Button layout
+	QHBoxLayout* buttonLayout = new QHBoxLayout;
+	buttonLayout->setContentsMargins(0, 0, 0, 0);
+
+	QPushButton* cancelButton = new QPushButton("Cancel");
+	connect(cancelButton, &QPushButton::clicked, [&]() { reject(); });
+	QPushButton* acceptButton = new QPushButton("Attach and Record");
+	connect(acceptButton, &QPushButton::clicked, [&]() { apply(); });
+	acceptButton->setDefault(true);
+
+	connect(m_processListWidget, &QTableView::doubleClicked, [&]() { apply(); });
+
+	buttonLayout->addStretch(1);
+	buttonLayout->addWidget(cancelButton);
+	buttonLayout->addWidget(acceptButton);
+
+	layout->addLayout(filterLayout);
+	layout->addLayout(optionsLayout);
+	layout->addSpacing(10);
+	layout->addLayout(buttonLayout);
+	setLayout(layout);
+
+	// Set default output directory
+	if (m_controller)
+		m_outputDirectory->setText(QString::fromStdString(m_controller->GetWorkingDirectory()));
+	m_traceChildProcesses->setChecked(false);
+
+	// Always use direct Windows enumeration to get command lines
+	m_processListWidget->updateContent(EnumerateProcessesWithCommandLine());
+
+	CoInitializeEx(NULL, COINIT_APARTMENTTHREADED | COINIT_DISABLE_OLE1DDE);
+}
+
+
+void TTDAttachDialog::apply()
+{
+	uint32_t pid = m_processListWidget->GetSelectedPid();
+	if (!pid)
+	{
+		QMessageBox::warning(this, "No Process Selected", "Please select a process to attach to.");
+		return;
+	}
+
+	DoTTDAttach(pid);
+	accept();
+}
+
+
+void TTDAttachDialog::DoTTDAttach(uint32_t pid)
+{
+	auto ttdPath = TTDRecordDialog::GetTTDRecorderPath();
+	if (ttdPath.empty())
+	{
+		QMessageBox::critical(this, "Recording Failed", "The debugger cannot find the path for the TTD recorder. "
+			"If you have set debugger.x64dbgEngPath, check if it is valid");
+		return;
+	}
+	LogDebug("TTD Recorder in path %s", ttdPath.c_str());
+
+	auto ttdRecorder = fmt::format("\"{}\\TTD.exe\"", ttdPath);
+	auto ttdCommandLine = fmt::format("-accepteula -out \"{}\" {} -attach {}",
+		m_outputDirectory->text().toStdString(),
+		m_traceChildProcesses->isChecked() ? "-children" : "",
+		pid);
+	LogWarn("TTD tracer cmd: %s %s", ttdRecorder.c_str(), ttdCommandLine.c_str());
+
+	SHELLEXECUTEINFOA info = {0};
+	info.cbSize = sizeof(SHELLEXECUTEINFOA);
+	info.fMask = SEE_MASK_NOCLOSEPROCESS;
+	info.lpVerb = "runas";
+	info.lpFile = ttdRecorder.c_str();
+	info.lpParameters = ttdCommandLine.c_str();
+	info.nShow = SW_NORMAL;
+	bool ret = ShellExecuteExA(&info);
+	if (ret == FALSE)
+	{
+		QMessageBox::critical(this, "Recording Failed", QString::asprintf("TTD attach failed: %lu", GetLastError()));
 		return;
 	}
 

--- a/ui/ttdrecord.h
+++ b/ui/ttdrecord.h
@@ -27,6 +27,7 @@ limitations under the License.
 #include "viewframe.h"
 #include "fontsettings.h"
 #include "debuggerapi.h"
+#include "attachprocess.h"
 
 using namespace BinaryNinjaDebuggerAPI;
 
@@ -46,7 +47,28 @@ private:
 public:
 	TTDRecordDialog(QWidget* parent, BinaryView* data);
 	void DoTTDTrace();
-	std::string GetTTDRecorderPath();
+	static std::string GetTTDRecorderPath();
+
+private Q_SLOTS:
+	void apply();
+};
+
+
+class TTDAttachDialog : public QDialog
+{
+	Q_OBJECT
+
+private:
+	DbgRef<DebuggerController> m_controller = nullptr;
+	ProcessListWidget* m_processListWidget;
+	FilteredView* m_filter;
+	FilterEdit* m_separateEdit;
+	QLineEdit* m_outputDirectory;
+	QCheckBox* m_traceChildProcesses;
+
+public:
+	TTDAttachDialog(QWidget* parent, BinaryView* data);
+	void DoTTDAttach(uint32_t pid);
 
 private Q_SLOTS:
 	void apply();

--- a/ui/ui.cpp
+++ b/ui/ui.cpp
@@ -1202,6 +1202,15 @@ void GlobalDebuggerUI::SetupMenu(UIContext* context)
 			}));
 	debuggerMenu->addAction("Record TTD Trace", "TTD");
 
+	UIAction::registerAction("Attach and Record TTD Trace");
+	context->globalActions()->bindAction("Attach and Record TTD Trace",
+		UIAction(
+			[=](const UIActionContext& ctxt) {
+				auto* dialog = new TTDAttachDialog(context->mainWindow(), ctxt.binaryView);
+				dialog->show();
+			}));
+	debuggerMenu->addAction("Attach and Record TTD Trace", "TTD");
+
 	UIAction::registerAction("Install WinDbg/TTD");
 	context->globalActions()->bindAction("Install WinDbg/TTD",
 		UIAction(


### PR DESCRIPTION
## Summary
- Adds TTDAttachDialog for attaching TTD.exe to running processes (closes #600)
- Adds "Attach and Record TTD Trace" menu action under Debugger > TTD submenu
- Adds command line column to process list for better process identification
- Updates DbgEngAdapter to use Windows APIs for local process enumeration to get command line information

## Changes
- **ui/ttdrecord.cpp/h**: New TTDAttachDialog class with process list, output directory, and trace child processes options
- **ui/attachprocess.cpp/h**: Added command line column to ProcessListModel and ProcessItem
- **ui/ui.cpp**: Added menu action for "Attach and Record TTD Trace"
- **core/adapters/dbgengadapter.cpp**: Uses Windows APIs (CreateToolhelp32Snapshot, NtQueryInformationProcess) for local process enumeration with command lines
- **core/debugadapter.h, api/debuggerapi.h, api/ffi.h**: Added m_commandLine field to DebugProcess struct
- **core/ffi.cpp, api/debuggercontroller.cpp**: Updated FFI layer to pass command line through

## Test plan
- [ ] Open Binary Ninja with debugger
- [ ] Go to Debugger > TTD > Attach and Record TTD Trace
- [ ] Verify process list shows with PID, Name, and Command Line columns
- [ ] Select a process and click Accept to attach TTD.exe to it
- [ ] Verify regular "Attach To Process" dialog also shows command line column

🤖 Generated with [Claude Code](https://claude.com/claude-code)