### PR TITLE
Add condition to breakpoint repr and add unit test for issue #953

### DIFF
--- a/api/python/debuggercontroller.py
+++ b/api/python/debuggercontroller.py
@@ -402,7 +402,8 @@ class DebugBreakpoint:
 
     def __repr__(self):
         status = "enabled" if self.enabled else "disabled"
-        return f"<DebugBreakpoint: {self.module}:{self.offset:#x}, {self.address:#x}, {status}>"
+        cond_str = f", condition='{self.condition}'" if self.condition else ""
+        return f"<DebugBreakpoint: {self.module}:{self.offset:#x}, {self.address:#x}, {status}{cond_str}>"
 
 
 class ModuleNameAndOffset:

--- a/test/debugger_test.py
+++ b/test/debugger_test.py
@@ -224,6 +224,51 @@ class DebuggerAPI(unittest.TestCase):
         self.assertEqual(dbg.get_breakpoint_condition(0x12345678), "")
         dbg.quit_and_wait()
 
+    def test_breakpoints_list_and_repr(self):
+        """Test that dbg.breakpoints returns correctly and repr includes condition"""
+        fpath = name_to_fpath('helloworld', self.arch)
+        bv = load(fpath)
+        dbg = DebuggerController(bv)
+        self.assertNotIn(dbg.launch_and_wait(), [DebugStopReason.ProcessExited, DebugStopReason.InternalError])
+
+        entry = dbg.data.entry_point
+        second_addr = entry + 4
+
+        # Add breakpoint without condition
+        dbg.add_breakpoint(entry)
+        # Add breakpoint with condition
+        dbg.add_breakpoint(second_addr)
+        arch_name = bv.arch.name
+        if arch_name == 'x86':
+            reg = 'eax'
+        elif arch_name == 'x86_64':
+            reg = 'rax'
+        else:
+            reg = 'x0'
+        condition = f"{reg} == 0x1234"
+        self.assertTrue(dbg.set_breakpoint_condition(second_addr, condition))
+
+        # Access dbg.breakpoints - this should not raise an error
+        # (regression test for issue #953 where None condition caused AttributeError)
+        breakpoints = dbg.breakpoints
+        self.assertGreaterEqual(len(breakpoints), 2)
+
+        # Test repr contains condition when set
+        bp_repr = repr(breakpoints)
+        self.assertIn(condition, bp_repr)
+
+        # Test individual breakpoint repr
+        for bp in breakpoints:
+            bp_str = repr(bp)
+            if bp.address == second_addr:
+                self.assertIn("condition=", bp_str)
+                self.assertIn(condition, bp_str)
+            elif bp.address == entry:
+                # Breakpoint without condition should not have condition in repr
+                self.assertNotIn("condition=", bp_str)
+
+        dbg.quit_and_wait()
+
     def test_register_read_write(self):
         fpath = name_to_fpath('helloworld', self.arch)
         bv = load(fpath)


### PR DESCRIPTION
## Summary
- Update `DebugBreakpoint.__repr__` to include condition when set
- Add `test_breakpoints_list_and_repr` test to verify `dbg.breakpoints` works correctly and includes condition in repr output

Fixes #953

## Test plan
- [ ] Run `test_breakpoints_list_and_repr` test to verify breakpoints can be accessed without error
- [ ] Verify breakpoint repr includes condition when set
- [ ] Verify breakpoint repr omits condition field when not set

🤖 Generated with [Claude Code](https://claude.com/claude-code)