### PR TITLE
Fix #994: Values wider than 8 bytes show as 0x0 in TTD memory widget

### DIFF
--- a/ui/ttdmemorywidget.cpp
+++ b/ui/ttdmemorywidget.cpp
@@ -436,9 +436,20 @@ void TTDMemoryQueryWidget::performQuery()
 			
 			// Size
 			m_resultsTable->setItem(i, 4, new NumericalTableWidgetItem(QString::number(event.size), event.size));
-			
-			// Value truncated to the number of bytes specified by size
-			QString valueStr = QString("0x%1").arg(event.value & ((1ULL << (event.size * 8)) - 1), 0, 16);
+
+			// Value - TTD always returns 8 bytes, so mask to the actual access size
+			// Note: For sizes > 8 bytes, TTD only provides the lower 8 bytes in the Value field
+			QString valueStr;
+			if (event.size < 8)
+			{
+				uint64_t mask = (1ULL << (event.size * 8)) - 1;
+				valueStr = QString("0x%1").arg(event.value & mask, 0, 16);
+			}
+			else
+			{
+				// For sizes >= 8, display the full 8-byte value
+				valueStr = QString("0x%1").arg(event.value, 0, 16);
+			}
 			m_resultsTable->setItem(i, 5, new NumericalTableWidgetItem(valueStr, event.value));
 			
 			// Thread ID


### PR DESCRIPTION
## Summary
- Fix undefined behavior in TTD memory widget display code when handling memory accesses > 8 bytes
- The original code used `1ULL << (event.size * 8)` which causes undefined behavior when size > 8 (shifting by >= 64 bits)
- On many platforms, this results in a mask of 0, causing values to display as 0x0

## Root Cause
The TTD data model only provides 8 bytes in the `Value` field, even for larger memory accesses (e.g., 16-byte XMM writes). The original display code attempted to mask the value based on `event.size`, but the bit-shift operation causes undefined behavior when `size * 8 >= 64`.

## Fix
- For sizes <= 8: Apply the mask properly using a conditional to avoid overflow
- For sizes > 8: Display the full 8-byte value without masking, since TTD truncates larger values to 8 bytes anyway

## Test plan
- [ ] Query memory accesses with sizes > 8 bytes (e.g., XMM register writes)
- [ ] Verify values display correctly instead of 0x0

Fixes #994

🤖 Generated with [Claude Code](https://claude.com/claude-code)