### PR TITLE
Fix crash when architecture string has no hyphen after colon

### DIFF
--- a/core/adapters/corelliumadapter.cpp
+++ b/core/adapters/corelliumadapter.cpp
@@ -137,7 +137,9 @@ bool CorelliumAdapter::LoadRegisterInfo()
 	if (architecture.find(':') != std::string::npos)
 	{
 		architecture.erase(0, architecture.find(':') + 1);
-		architecture.replace(architecture.find('-'), 1, "_");
+		auto hyphenPos = architecture.find('-');
+		if (hyphenPos != std::string::npos)
+			architecture.replace(hyphenPos, 1, "_");
 	}
 	m_remoteArch = architecture;
 

--- a/core/adapters/esrevenadapter.cpp
+++ b/core/adapters/esrevenadapter.cpp
@@ -160,7 +160,9 @@ bool EsrevenAdapter::LoadRegisterInfo()
 	if (architecture.find(':') != std::string::npos)
 	{
 		architecture.erase(0, architecture.find(':') + 1);
-		architecture.replace(architecture.find('-'), 1, "_");
+		auto hyphenPos = architecture.find('-');
+		if (hyphenPos != std::string::npos)
+			architecture.replace(hyphenPos, 1, "_");
 	}
 	m_remoteArch = architecture;
 

--- a/core/adapters/gdbadapter.cpp
+++ b/core/adapters/gdbadapter.cpp
@@ -160,7 +160,9 @@ bool GdbAdapter::LoadRegisterInfo()
 	if (architecture.find(':') != std::string::npos)
 	{
 		architecture.erase(0, architecture.find(':') + 1);
-		architecture.replace(architecture.find('-'), 1, "_");
+		auto hyphenPos = architecture.find('-');
+		if (hyphenPos != std::string::npos)
+			architecture.replace(hyphenPos, 1, "_");
 	}
 	m_remoteArch = architecture;
 


### PR DESCRIPTION
## Summary
- Fixes crash in GDB RSP adapter when connecting to QEMU-PPC targets
- Architecture strings like `powerpc:common` contain a colon but no hyphen
- `string::find('-')` was returning `npos`, which when passed to `replace()` causes a crash
- Added npos check before calling `replace()` in all 3 affected adapters: `gdbadapter.cpp`, `corelliumadapter.cpp`, and `esrevenadapter.cpp`

Fixes #1000

## Test plan
- [ ] Connect to QEMU-PPC target with architecture string `powerpc:common`
- [ ] Verify debugger no longer crashes on connection
- [ ] Test with architecture strings that DO contain hyphens to ensure backward compatibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)