### PR TITLE
Fixed general bugs

### DIFF
--- a/api/python/debuggercontroller.py
+++ b/api/python/debuggercontroller.py
@@ -83,7 +83,7 @@ class DebugProcess:
         return not (self == other)
 
     def __hash__(self):
-        return hash((self.pid, self.pid))
+        return hash((self.pid, self.name))
 
     def __setattr__(self, name, value):
         try:
@@ -1586,7 +1586,7 @@ class DebuggerController:
         """
         Detach the target, and let it execute on its own.
         """
-        dbgcore.BNDebuggerQuit(self.handle)
+        dbgcore.BNDebuggerDetach(self.handle)
 
     def pause(self) -> None:
         """
@@ -2072,12 +2072,12 @@ class DebuggerController:
 
         ``pid_attach`` is only useful for connecting to a running process using PID.
 
-        :getter: returns the remote port
-        :setter: sets the remote port
+        :getter: returns the PID to attach to
+        :setter: sets the PID to attach to
         """
         return dbgcore.BNDebuggerGetPIDAttach(self.handle)
 
-    @remote_port.setter
+    @pid_attach.setter
     def pid_attach(self, pid: int) -> None:
         dbgcore.BNDebuggerSetPIDAttach(self.handle, pid)
 
@@ -2494,7 +2494,9 @@ class DebuggerController:
         return dbgcore.BNDebuggerSetAdapterProperty(self.handle, name, handle)
 
     def get_addr_info(self, addr: int):
-        return dbgcore.BNDebuggerGetAddressInformation(self.handle, addr)
+        buffer = addr.to_bytes(64, byteorder='little', signed=False)
+        c_buffer = (ctypes.c_ubyte * 64)(*buffer)
+        return dbgcore.BNDebuggerGetAddressInformation(self.handle, c_buffer)
 
     @property
     def is_first_launch(self):

--- a/core/adapters/dbgengttdadapter.cpp
+++ b/core/adapters/dbgengttdadapter.cpp
@@ -116,7 +116,7 @@ bool DbgEngTTDAdapter::Start()
 
 	auto handle = GetModuleHandleA("dbgeng.dll");
 	if (handle == nullptr)
-		false;
+		return false;
 
 	//    HRESULT DebugCreate(
 	//    [in]  REFIID InterfaceId,

--- a/core/adapters/gdbadapter.cpp
+++ b/core/adapters/gdbadapter.cpp
@@ -1376,7 +1376,7 @@ std::string GdbAdapter::InvokeBackendCommand(const std::string& command)
 	if (command.substr(0, 4) == "mon ")
 		return RunMonitorCommand(command.substr(4));
 	else if (command.substr(0, 8) == "monitor ")
-		return RunMonitorCommand(command.substr(4));
+		return RunMonitorCommand(command.substr(8));
 
 	auto reply = this->m_rspConnector->TransmitAndReceive(RspData(command));
 	return reply.AsString();

--- a/core/debuggercontroller.cpp
+++ b/core/debuggercontroller.cpp
@@ -1263,7 +1263,6 @@ DebugStopReason DebuggerController::RunToAndWaitInternal(const std::vector<uint6
 		}
 	}
 
-	NotifyStopped(reason);
 	return reason;
 }
 
@@ -1290,7 +1289,6 @@ DebugStopReason DebuggerController::RunToReverseAndWaitInternal(const std::vecto
 		}
 	}
 
-	NotifyStopped(reason);
 	return reason;
 }
 
@@ -1534,7 +1532,11 @@ void DebuggerController::DetachAndWait()
 		locked = true;
 
 	if (!m_state->IsConnected())
+	{
+		if (locked)
+			m_targetControlMutex.unlock();
 		return;
+	}
 
 	// TODO: return whether the operation is successful
 	ExecuteAdapterAndWait(DebugAdapterDetach);
@@ -1563,7 +1565,11 @@ void DebuggerController::QuitAndWait()
 		locked = true;
 
 	if (!m_state->IsConnected())
+	{
+		if (locked)
+			m_targetControlMutex.unlock();
 		return;
+	}
 
 	if (m_state->IsRunning())
 	{

--- a/core/debuggerstate.cpp
+++ b/core/debuggerstate.cpp
@@ -330,12 +330,13 @@ bool DebuggerThreads::SuspendThread(std::uint32_t tid)
 	if (!adapter)
 		return false;
 
-	auto threads = GetAllThreads();
-	auto thread = std::find_if(threads.begin(), threads.end(), [&](DebugThread const& t) {
+	std::unique_lock lock(m_threadsMutex);
+
+	auto thread = std::find_if(m_threads.begin(), m_threads.end(), [&](DebugThread const& t) {
 		return t.m_tid == tid;
 	});
 
-	if (thread == threads.end())
+	if (thread == m_threads.end())
 		return false;
 
 
@@ -360,12 +361,13 @@ bool DebuggerThreads::ResumeThread(std::uint32_t tid)
 	if (!adapter)
 		return false;
 
-	auto threads = GetAllThreads();
-	auto thread = std::find_if(threads.begin(), threads.end(), [&](DebugThread const& t) {
+	std::unique_lock lock(m_threadsMutex);
+
+	auto thread = std::find_if(m_threads.begin(), m_threads.end(), [&](DebugThread const& t) {
 		return t.m_tid == tid;
 	});
 
-	if (thread == threads.end())
+	if (thread == m_threads.end())
 		return false;
 
 	if (!thread->m_isFrozen)

--- a/ui/threadframes.h
+++ b/ui/threadframes.h
@@ -99,7 +99,7 @@ private:
 	uint64_t m_fp {};
 
 	QList<FrameItem*> m_childItems;
-	FrameItem* m_parentItem;
+	FrameItem* m_parentItem {nullptr};
 };
 
 Q_DECLARE_METATYPE(FrameItem);


### PR DESCRIPTION
Took some time to explore the codebase a bit and cleaned up a few issues I found.

1. `detach()` called `BNDebuggerQuit` instead of `BNDebuggerDetach`
2. `pid_attach` setter was broken and didn't use the correct decorator (was a copy-paste of the port setter stuff), likewise with the doc for it.
3. `get_addr_info` wasn't usable due to the fact a plain int was passed where the FFI expected a 64-byte buffer
4. `__hash__` used (pid, pid) instead of (pid, name) which never matched the `__eq__`
5. `SuspendThread`/`ResumeThread` never persisted freeze state, `GetAllThreads()` returns by value, so `m_isFrozen` was set on a local copy
6. `DetachAndWait`/`QuitAndWait` leaked mutex on early return due to `m_targetControlMutex` staying locked if `IsConnected()` returned false
7. `RunTo` sent duplicated stop events to the UI, `NotifyStopped` is called in both *Internal and *AndWait, unlike any other operation
8. `DbgEngTTDAdapter::Start()` didn't `return false`, so may cause it to fall through - this is now fixed.
10. In GDB, `substr(4)` would have corrupted the `monitor` command, now it's `substr(8)`.
11. Initialise `m_parentItem` pointer to avoid possible garbage read (unlikely but also just consistency)
