### PR TITLE
Fix compiler warnings

### DIFF
--- a/core/adapters/esrevenadapter.cpp
+++ b/core/adapters/esrevenadapter.cpp
@@ -2901,7 +2901,6 @@ std::vector<TTDCallEvent> EsrevenAdapter::GetTTDCallsForSymbols(const std::strin
 			uint64_t transition_id = extractUInt64("transition_id");
 			std::string function_name = extractString("function_name");
 			uint64_t function_address = extractUInt64("function_address");
-			uint64_t call_instruction_address = extractUInt64("call_instruction_address");
 			uint64_t return_address = extractUInt64("return_address");
 			uint64_t thread_id = extractUInt64("thread_id");
 

--- a/core/adapters/gdbadapter.cpp
+++ b/core/adapters/gdbadapter.cpp
@@ -821,8 +821,8 @@ std::vector<DebugModule> GdbAdapter::GetModuleList()
 	if (m_moduleCache.has_value())
 		return m_moduleCache.value();
 
-    if (m_isTargetRunning)
-        return {};
+	if (m_isTargetRunning)
+		return {};
 
 	if (!m_rspConnector)
 		return {};


### PR DESCRIPTION
The unused variable warning has been present with with Clang since the code was added. I did not see any obvious place where `call_instruction_address` should be used so I removed the variable entirely.

The misleading indentation warning only showed up after I updated to Xcode 26.4. It includes a newer version of Clang, based on Clang 21.