### PR TITLE
Stop focusing debugger sidebar on every target stop

### DIFF
--- a/ui/ui.cpp
+++ b/ui/ui.cpp
@@ -1990,8 +1990,6 @@ void DebuggerUI::updateUI(const DebuggerEvent& event)
 		auto* globalUI = GlobalDebuggerUI::GetForContext(m_context);
 		if (globalUI)
 			globalUI->SetDisplayingGlobalAreaWidgets(true);
-
-		openDebuggerSideBar();
 	}
 
 	switch (event.type)

--- a/ui/ui.cpp
+++ b/ui/ui.cpp
@@ -1828,7 +1828,6 @@ void DebuggerUI::navigateDebugger(uint64_t address)
 			frame->navigate(m_controller->GetData(), address, true, true);
 	}
 
-	openDebuggerSideBar(frame);
 	m_context->refreshCurrentViewContents();
 }
 
@@ -1991,6 +1990,8 @@ void DebuggerUI::updateUI(const DebuggerEvent& event)
 		auto* globalUI = GlobalDebuggerUI::GetForContext(m_context);
 		if (globalUI)
 			globalUI->SetDisplayingGlobalAreaWidgets(true);
+
+		openDebuggerSideBar();
 	}
 
 	switch (event.type)


### PR DESCRIPTION
## Summary
- Only open the debugger sidebar once when a debug session starts (Launch/Attach/Connect), instead of on every `navigateDebugger` call triggered by target stops
- This prevents the sidebar from stealing focus away from other sidebars (e.g., Sidekick) during debugging

## Test plan
- [ ] Start a debug session — debugger sidebar should open
- [ ] Hit a breakpoint / step — debugger sidebar should NOT steal focus from the currently active sidebar
- [ ] Verify navigation to current IP still works correctly on stop

Fixes #1032

🤖 Generated with [Claude Code](https://claude.com/claude-code)