### PR TITLE
Fix crash from joining the event thread on itself

### DIFF
--- a/core/debuggercontroller.cpp
+++ b/core/debuggercontroller.cpp
@@ -1875,13 +1875,18 @@ void DebuggerController::EventHandler(const DebuggerEvent& event)
 
 		if (m_accessor)
 		{
-			// Defer deletion to a worker thread. The accessor holds a DbgRef<DebuggerController>,
+			// Defer deletion to a detached thread. The accessor holds a DbgRef<DebuggerController>,
 			// and if it is the last reference, deleting it here (on the event thread) would trigger
-			// ~DebuggerController which calls m_debuggerEventThread.join() -- deadlocking because
-			// we ARE the event thread.
+			// ~DebuggerController which calls m_debuggerEventThread.join() -- deadlocking/crashing
+			// because we ARE the event thread.
+			//
+			// This can happen when Destroy() races with event processing: EventHandler sets
+			// ConnectionStatus to NotConnected (line above), and another thread observes this,
+			// calls Destroy() which removes the global array ref, making the accessor's DbgRef
+			// the last reference to the controller.
 			auto* accessor = m_accessor;
 			m_accessor = nullptr;
-			BinaryNinja::WorkerEnqueue([accessor]() { delete accessor; });
+			std::thread([accessor]() { delete accessor; }).detach();
 		}
 		m_lastIP = m_currentIP;
 		m_currentIP = 0;

--- a/core/debuggercontroller.cpp
+++ b/core/debuggercontroller.cpp
@@ -1875,8 +1875,13 @@ void DebuggerController::EventHandler(const DebuggerEvent& event)
 
 		if (m_accessor)
 		{
-			delete m_accessor;
+			// Defer deletion to a worker thread. The accessor holds a DbgRef<DebuggerController>,
+			// and if it is the last reference, deleting it here (on the event thread) would trigger
+			// ~DebuggerController which calls m_debuggerEventThread.join() -- deadlocking because
+			// we ARE the event thread.
+			auto* accessor = m_accessor;
 			m_accessor = nullptr;
+			BinaryNinja::WorkerEnqueue([accessor]() { delete accessor; });
 		}
 		m_lastIP = m_currentIP;
 		m_currentIP = 0;


### PR DESCRIPTION
## Summary
- Defer `delete m_accessor` in `EventHandler` to a detached `std::thread`
- The `DebuggerFileAccessor` holds a `DbgRef<DebuggerController>`, and when it's the last reference, deleting it on the event thread triggers `~DebuggerController` which calls `m_debuggerEventThread.join()` — crashing because we ARE the event thread
- Root cause is a race condition: `EventHandler` sets `ConnectionStatus(NotConnected)` before deleting the accessor, and another thread (UI close path or Python) can observe this, call `Destroy()` to remove the global array ref, making the accessor's `DbgRef` the last reference
- By deferring the deletion to a detached thread, the controller's destructor runs off the event thread where `join()` succeeds normally

## Test plan
- [ ] Debug a target, let it exit normally — verify no crash on exit
- [ ] Debug a target, detach — verify no crash on detach
- [ ] Trigger a launch failure (e.g., invalid remote address) — verify no crash
- [ ] Close a file tab while the target is exiting — verify no crash

Fixes #1038

🤖 Generated with [Claude Code](https://claude.com/claude-code)