### PR TITLE
Fix use-after-free crash in UI callbacks on rebase

### DIFF
--- a/api/debuggercontroller.cpp
+++ b/api/debuggercontroller.cpp
@@ -1001,7 +1001,10 @@ void DebuggerController::RemoveEventCallback(size_t index)
 
 void DebuggerController::SetDebuggerUICallbacks(DebuggerUICallbacks* cb)
 {
-	BNDebuggerSetDebuggerUICallbacks(m_object, cb->GetCallbacks(), cb);
+	if (cb)
+		BNDebuggerSetDebuggerUICallbacks(m_object, cb->GetCallbacks(), cb);
+	else
+		BNDebuggerSetDebuggerUICallbacks(m_object, nullptr, nullptr);
 }
 
 

--- a/core/debuggercontroller.cpp
+++ b/core/debuggercontroller.cpp
@@ -4757,7 +4757,10 @@ Ref<Settings> DebuggerController::GetAdapterSettings()
 
 void DebuggerController::SetDebuggerUICallbacks(BNDebuggerUICallbacks* cb, void* ctxt)
 {
-	m_uiCallbacks = std::make_unique<DebuggerUICallbacks>(cb, ctxt);
+	if (cb)
+		m_uiCallbacks = std::make_unique<DebuggerUICallbacks>(cb, ctxt);
+	else
+		m_uiCallbacks.reset();
 }
 
 

--- a/ui/ui.cpp
+++ b/ui/ui.cpp
@@ -1709,6 +1709,9 @@ DebuggerUI::DebuggerUI(UIContext* context, DebuggerControllerRef controller) :
 
 DebuggerUI::~DebuggerUI()
 {
+	// Unregister UI callbacks from the controller before deleting them, so the controller
+	// does not invoke a dangling callback if events arrive after the UI is destroyed.
+	m_controller->SetDebuggerUICallbacks(nullptr);
 	if (m_uiCallbacks)
 	{
 		delete m_uiCallbacks;


### PR DESCRIPTION
## Summary
- Unregister UI callbacks from the `DebuggerController` in `~DebuggerUI()` before deleting them, preventing a use-after-free crash when the controller processes a rebase after the UI is destroyed.
- `SetDebuggerUICallbacks` now accepts `nullptr` to clear the callbacks. The existing null check in `RebaseToAddress()` ensures any rebase attempt after UI destruction safely returns `false`.

## Test plan
- [ ] Launch a debug target, then close the binary view tab before the launch completes. Verify no crash occurs when the target eventually stops and triggers a rebase.
- [ ] Normal debugging workflow (launch, hit breakpoints, rebase) still works correctly with UI open.

Fixes #1039

🤖 Generated with [Claude Code](https://claude.com/claude-code)