### PR TITLE
Fix native Windows adapter broken after detach

### DIFF
--- a/core/adapters/windowsnativeadapter.cpp
+++ b/core/adapters/windowsnativeadapter.cpp
@@ -238,23 +238,6 @@ bool WindowsNativeAdapter::Detach()
 	// Wake up the debug thread if it's waiting
 	m_debugCondition.notify_one();
 
-	// Remove all breakpoints before detaching
-	{
-		std::lock_guard<std::mutex> lock(m_breakpointsMutex);
-		for (auto& bp : m_breakpoints)
-		{
-			if (bp.isActive)
-				RemoveBreakpointInternal(bp.address);
-		}
-		m_breakpoints.clear();
-	}
-
-	if (!DebugActiveProcessStop(m_processId))
-	{
-		LogError("Failed to detach from process: %d", GetLastError());
-		return false;
-	}
-
 	if (m_debugThread.joinable())
 		m_debugThread.join();
 
@@ -563,7 +546,23 @@ void WindowsNativeAdapter::DebugLoop()
 
 			if (m_shouldStop)
 			{
+				// Remove all breakpoints before detaching
+				{
+					std::lock_guard<std::mutex> lock(m_breakpointsMutex);
+					for (auto& bp : m_breakpoints)
+					{
+						if (bp.isActive)
+							RemoveBreakpointInternal(bp.address);
+					}
+					m_breakpoints.clear();
+				}
+
 				ContinueDebugEvent(debugEvent.dwProcessId, debugEvent.dwThreadId, DBG_CONTINUE);
+
+				// DebugActiveProcessStop must be called from the same thread that started debugging
+				if (!DebugActiveProcessStop(m_processId))
+					LogWarn("DebugActiveProcessStop failed (error %d)", GetLastError());
+
 				break;
 			}
 		}
@@ -586,6 +585,24 @@ void WindowsNativeAdapter::DebugLoop()
 		}
 
 		ContinueDebugEvent(debugEvent.dwProcessId, debugEvent.dwThreadId, continueStatus);
+	}
+
+	// If we exited the loop due to m_shouldStop while the target was running (not stopped at a
+	// breakpoint), we still need to detach. The stopped-at-breakpoint case is handled inside the loop.
+	if (m_shouldStop && m_activelyDebugging)
+	{
+		{
+			std::lock_guard<std::mutex> lock(m_breakpointsMutex);
+			for (auto& bp : m_breakpoints)
+			{
+				if (bp.isActive)
+					RemoveBreakpointInternal(bp.address);
+			}
+			m_breakpoints.clear();
+		}
+
+		if (!DebugActiveProcessStop(m_processId))
+			LogWarn("DebugActiveProcessStop failed (error %d)", GetLastError());
 	}
 
 	m_activelyDebugging = false;


### PR DESCRIPTION
## Summary
- `DebugActiveProcessStop` must be called from the same thread that called `DebugActiveProcess`. Previously it was called from the main thread in `Detach()`, causing `ERROR_ACCESS_DENIED` and crashing the target process.
- Moved `DebugActiveProcessStop` (and breakpoint cleanup) into `DebugLoop()` on the debug thread, handling both the stopped-at-breakpoint and target-running cases.

Fixes #1041

## Test plan
- [x] Attach to a process with the native Windows adapter
- [x] Detach from the process
- [x] Verify the process continues running
- [x] Verify the adapter can be used again

🤖 Generated with [Claude Code](https://claude.com/claude-code)