### PR TITLE
Fix mutex2 deadlock and ResumeEvent spam with conditional breakpoints

### DIFF
--- a/core/debuggercontroller.cpp
+++ b/core/debuggercontroller.cpp
@@ -2077,6 +2077,7 @@ void DebuggerController::DebuggerMainThread()
 					m_suppressResumeEvent = true;
 					m_adapter->Go();
 					m_suppressResumeEvent = false;
+					m_state->SetExecutionStatus(DebugAdapterRunningStatus);
 					continue;
 				}
 			}

--- a/core/debuggercontroller.cpp
+++ b/core/debuggercontroller.cpp
@@ -1986,6 +1986,12 @@ bool DebuggerController::RemoveEventCallbackInternal(size_t index)
 
 void DebuggerController::PostDebuggerEvent(const DebuggerEvent& event)
 {
+	// During conditional breakpoint auto-resume, suppress the ResumeEventType that adapters
+	// post inside Go(). The target is already considered running by the UI, and posting this
+	// event from the dispatcher thread would trigger a re-entrant warning.
+	if (m_suppressResumeEvent && event.type == ResumeEventType)
+		return;
+
 	auto pending = std::make_shared<PendingEvent>();
 	pending->event = event;
 	std::future<void> future = pending->done.get_future();
@@ -2059,13 +2065,18 @@ void DebuggerController::DebuggerMainThread()
 			if (uint64_t ip = m_state->IP();
 				!isStepOperation && m_state->GetBreakpoints()->ContainsAbsolute(ip))
 			{
-				if (!EvaluateBreakpointCondition(ip))
+				if (!EvaluateBreakpointCondition(ip) && !m_userRequestedBreak)
 				{
 					m_lastAdapterStopEventConsumed = true;
 					current->done.set_value();
-					// using m_adapter->Go() directly instead of Go() to avoid mutex deadlock
-					// since we're already inside ExecuteAdapterAndWait's event processing
+					// Using m_adapter->Go() directly instead of Go() to avoid mutex deadlock
+					// since we're already inside ExecuteAdapterAndWait's event processing.
+					// Suppress the ResumeEventType that some adapters post synchronously inside
+					// Go() — the UI already considers the target running, and posting from the
+					// dispatcher thread would be unexpected.
+					m_suppressResumeEvent = true;
 					m_adapter->Go();
+					m_suppressResumeEvent = false;
 					continue;
 				}
 			}

--- a/core/debuggercontroller.h
+++ b/core/debuggercontroller.h
@@ -121,6 +121,10 @@ namespace BinaryNinjaDebugger {
 
 		bool m_lastAdapterStopEventConsumed = true;
 
+		// When true, ResumeEventType events are suppressed in PostDebuggerEvent.
+		// Used during conditional breakpoint auto-resume to avoid posting events from the dispatcher thread.
+		bool m_suppressResumeEvent = false;
+
 		bool m_inputFileLoaded = false;
 		bool m_initialBreakpointSeen = false;
 


### PR DESCRIPTION
## Summary

Fixes #1037

- **Mutex2 deadlock**: When a conditional breakpoint evaluates to false, the auto-resume path (`continue` at line 2069) skips callback dispatch. If a Pause/Quit/Detach operation is pending, its callback never fires, its semaphore never releases, and `m_adapterMutex2` is permanently locked. Fix: check `m_userRequestedBreak` before auto-resuming so an explicit Pause is honored over the breakpoint condition.
- **ResumeEventType warning spam**: Adapters that post `ResumeEventType` synchronously inside `Go()` (WindowsNativeAdapter, GdbAdapter, EsrevenAdapter, CorelliumAdapter) trigger re-entrant warnings when called from the dispatcher thread. Fix: suppress the unnecessary `ResumeEventType` during auto-resume via a flag checked in `PostDebuggerEvent`. Adapters that post asynchronously (LLDB, DbgEng) are unaffected.

## Test plan

- [ ] Open helloworld_thread binary for Windows x86_64
- [ ] Launch with native Windows adapter
- [ ] Continue past initial breakpoint
- [ ] Pause, set a conditional breakpoint like `rax == 0x1234`
- [ ] Continue — verify no "type 1 posted from dispatcher" warnings
- [ ] Pause — verify it succeeds without "Cannot obtain mutex2" errors
- [ ] Restart/quit — verify these also work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)