### PR TITLE
Fix TTD sidebar widgets showing on non-TTD platforms

### DIFF
--- a/ui/ttdbookmarkwidget.cpp
+++ b/ui/ttdbookmarkwidget.cpp
@@ -606,5 +606,5 @@ SidebarWidget* TTDBookmarkWidgetType::createWidget(ViewFrame* frame, BinaryViewR
 
 SidebarContentClassifier* TTDBookmarkWidgetType::contentClassifier(ViewFrame*, BinaryViewRef data)
 {
-	return new ActiveDebugSessionSidebarContentClassifier(data);
+	return new ActiveDebugSessionSidebarContentClassifier(data, true);
 }

--- a/ui/ttdcallswidget.cpp
+++ b/ui/ttdcallswidget.cpp
@@ -839,7 +839,7 @@ SidebarWidget* TTDCallsWidgetType::createWidget(ViewFrame* frame, BinaryViewRef 
 
 SidebarContentClassifier* TTDCallsWidgetType::contentClassifier(ViewFrame*, BinaryViewRef data)
 {
-	return new ActiveDebugSessionSidebarContentClassifier(data);
+	return new ActiveDebugSessionSidebarContentClassifier(data, true);
 }
 
 void TTDCallsWidgetType::SetPendingQuery(

--- a/ui/ttdeventswidget.cpp
+++ b/ui/ttdeventswidget.cpp
@@ -1197,5 +1197,5 @@ SidebarWidget* TTDEventsWidgetType::createWidget(ViewFrame* frame, BinaryViewRef
 
 SidebarContentClassifier* TTDEventsWidgetType::contentClassifier(ViewFrame*, BinaryViewRef data)
 {
-	return new ActiveDebugSessionSidebarContentClassifier(data);
+	return new ActiveDebugSessionSidebarContentClassifier(data, true);
 }

--- a/ui/ttdmemorywidget.cpp
+++ b/ui/ttdmemorywidget.cpp
@@ -1327,7 +1327,7 @@ SidebarWidget* TTDMemoryWidgetType::createWidget(ViewFrame* frame, BinaryViewRef
 
 SidebarContentClassifier* TTDMemoryWidgetType::contentClassifier(ViewFrame*, BinaryViewRef data)
 {
-	return new ActiveDebugSessionSidebarContentClassifier(data);
+	return new ActiveDebugSessionSidebarContentClassifier(data, true);
 }
 
 void TTDMemoryWidgetType::SetPendingQuery(ViewFrame* frame, BinaryViewRef data, uint64_t startAddr, uint64_t endAddr, TTDMemoryAccessType accessType)

--- a/ui/ui.cpp
+++ b/ui/ui.cpp
@@ -2181,12 +2181,13 @@ extern "C"
 }
 
 
-ActiveDebugSessionSidebarContentClassifier::ActiveDebugSessionSidebarContentClassifier(BinaryViewRef data)
+ActiveDebugSessionSidebarContentClassifier::ActiveDebugSessionSidebarContentClassifier(BinaryViewRef data, bool requireTTD) :
+	m_requireTTD(requireTTD)
 {
 	m_debugger = DebuggerController::GetController(data);
 	if (m_debugger)
 	{
-		if (m_debugger->IsConnected())
+		if (m_debugger->IsConnected() && (!m_requireTTD || m_debugger->IsTTD()))
 			m_contentClassification = SidebarHasRelevantContent;
 
 		m_eventIndex = m_debugger->RegisterEventCallback(
@@ -2197,7 +2198,8 @@ ActiveDebugSessionSidebarContentClassifier::ActiveDebugSessionSidebarContentClas
 				case ResumeEventType:
 				case StepIntoEventType:
 				case TargetStoppedEventType:
-					m_contentClassification = SidebarHasRelevantContent;
+					if (!m_requireTTD || (m_debugger && m_debugger->IsTTD()))
+						m_contentClassification = SidebarHasRelevantContent;
 					Q_EMIT contentClassificationChanged();
 					break;
 				case DetachedEventType:

--- a/ui/ui.h
+++ b/ui/ui.h
@@ -108,9 +108,10 @@ class ActiveDebugSessionSidebarContentClassifier : public SidebarContentClassifi
 	size_t m_eventIndex;
 	SidebarContentClassification m_contentClassification = SidebarHasNoContent;
 	DebuggerControllerRef m_debugger;
+	bool m_requireTTD;
 
 public:
-	ActiveDebugSessionSidebarContentClassifier(BinaryViewRef data);
+	ActiveDebugSessionSidebarContentClassifier(BinaryViewRef data, bool requireTTD = false);
 	~ActiveDebugSessionSidebarContentClassifier() override;
 	SidebarContentClassification contentClassification() override { return m_contentClassification; }
 };


### PR DESCRIPTION
## Summary
- Fixes #1055 — TTD sidebar widgets (Events, Memory, Calls, Bookmarks) were appearing during any active debug session, including on platforms like macOS that don't support TTD
- Adds a `requireTTD` boolean parameter to `ActiveDebugSessionSidebarContentClassifier` that additionally checks `IsTTD()` before showing content
- The 4 TTD widget types now pass `requireTTD=true`; non-TTD widgets are unaffected (default is `false`)

## Test plan
- [ ] Debug a non-TTD target (e.g. LLDB on macOS) and verify the 4 TTD sidebar widgets do not appear
- [ ] Debug a TTD target on Windows and verify the 4 TTD sidebar widgets still appear correctly
- [ ] Verify non-TTD sidebar widgets (Modules, ThreadFrames, DebugInfo) still appear during any debug session

🤖 Generated with [Claude Code](https://claude.com/claude-code)