### PR TITLE
Fix AttachProcessDialog leak causing DebuggerController ref leak

### DIFF
--- a/ui/ui.cpp
+++ b/ui/ui.cpp
@@ -857,9 +857,13 @@ void GlobalDebuggerUI::SetupMenu(UIContext* context)
 
 				auto dialog = new AttachProcessDialog(context->mainWindow(), controller);
 				if (dialog->exec() != QDialog::Accepted)
+				{
+					dialog->deleteLater();
 					return;
+				}
 
 				uint32_t pid = dialog->GetSelectedPid();
+				dialog->deleteLater();
 				if (pid == 0)
 					return;
 

--- a/ui/ui.cpp
+++ b/ui/ui.cpp
@@ -855,15 +855,11 @@ void GlobalDebuggerUI::SetupMenu(UIContext* context)
 						return;
 				}
 
-				auto dialog = new AttachProcessDialog(context->mainWindow(), controller);
-				if (dialog->exec() != QDialog::Accepted)
-				{
-					dialog->deleteLater();
+				AttachProcessDialog dialog(context->mainWindow(), controller);
+				if (dialog.exec() != QDialog::Accepted)
 					return;
-				}
 
-				uint32_t pid = dialog->GetSelectedPid();
-				dialog->deleteLater();
+				uint32_t pid = dialog.GetSelectedPid();
 				if (pid == 0)
 					return;
 


### PR DESCRIPTION
## Summary
- `AttachProcessDialog` was heap-allocated with `new` but never freed in the attach action handler (`ui/ui.cpp`)
- Since it owns a `ProcessListWidget` which holds a `DbgRef<DebuggerController>`, this also caused the controller to leak
- Added `deleteLater()` on all exit paths after the dialog is used

## Test plan
- [ ] Open a binary, attach to a process via the debugger, then stop debugging and close the file
- [ ] Verify no `DebuggerController` leak is reported in the leak detector

Fix #1061

🤖 Generated with [Claude Code](https://claude.com/claude-code)