### PR TITLE
added the use settings next time checkbox to adapter settings dialog

### DIFF
--- a/api/debuggerapi.h
+++ b/api/debuggerapi.h
@@ -830,6 +830,16 @@ namespace BinaryNinjaDebuggerAPI {
 		bool IsFirstConnectToDebugServer();
 		bool IsFirstAttach();
 
+		bool ShouldShowAdapterSettingsNextLaunch();
+		bool ShouldShowAdapterSettingsNextAttach();
+		bool ShouldShowAdapterSettingsNextConnect();
+		bool ShouldShowAdapterSettingsNextConnectToDebugServer();
+
+		void SetShowAdapterSettingsNextLaunch(bool value);
+		void SetShowAdapterSettingsNextAttach(bool value);
+		void SetShowAdapterSettingsNextConnect(bool value);
+		void SetShowAdapterSettingsNextConnectToDebugServer(bool value);
+
 		bool IsTTD();
 
 		// TTD Memory Analysis Methods

--- a/api/debuggercontroller.cpp
+++ b/api/debuggercontroller.cpp
@@ -1094,6 +1094,54 @@ bool DebuggerController::IsFirstAttach()
 }
 
 
+bool DebuggerController::ShouldShowAdapterSettingsNextLaunch()
+{
+	return BNDebuggerShouldShowAdapterSettingsNextLaunch(m_object);
+}
+
+
+bool DebuggerController::ShouldShowAdapterSettingsNextAttach()
+{
+	return BNDebuggerShouldShowAdapterSettingsNextAttach(m_object);
+}
+
+
+bool DebuggerController::ShouldShowAdapterSettingsNextConnect()
+{
+	return BNDebuggerShouldShowAdapterSettingsNextConnect(m_object);
+}
+
+
+bool DebuggerController::ShouldShowAdapterSettingsNextConnectToDebugServer()
+{
+	return BNDebuggerShouldShowAdapterSettingsNextConnectToDebugServer(m_object);
+}
+
+
+void DebuggerController::SetShowAdapterSettingsNextLaunch(bool value)
+{
+	BNDebuggerSetShowAdapterSettingsNextLaunch(m_object, value);
+}
+
+
+void DebuggerController::SetShowAdapterSettingsNextAttach(bool value)
+{
+	BNDebuggerSetShowAdapterSettingsNextAttach(m_object, value);
+}
+
+
+void DebuggerController::SetShowAdapterSettingsNextConnect(bool value)
+{
+	BNDebuggerSetShowAdapterSettingsNextConnect(m_object, value);
+}
+
+
+void DebuggerController::SetShowAdapterSettingsNextConnectToDebugServer(bool value)
+{
+	BNDebuggerSetShowAdapterSettingsNextConnectToDebugServer(m_object, value);
+}
+
+
 bool DebuggerController::IsTTD()
 {
 	return BNDebuggerIsTTD(m_object);

--- a/api/ffi.h
+++ b/api/ffi.h
@@ -679,6 +679,16 @@ extern "C"
 	DEBUGGER_FFI_API bool BNDebuggerIsFirstConnectToDebugServer(BNDebuggerController* controller);
 	DEBUGGER_FFI_API bool BNDebuggerIsFirstAttach(BNDebuggerController* controller);
 
+	DEBUGGER_FFI_API bool BNDebuggerShouldShowAdapterSettingsNextLaunch(BNDebuggerController* controller);
+	DEBUGGER_FFI_API bool BNDebuggerShouldShowAdapterSettingsNextAttach(BNDebuggerController* controller);
+	DEBUGGER_FFI_API bool BNDebuggerShouldShowAdapterSettingsNextConnect(BNDebuggerController* controller);
+	DEBUGGER_FFI_API bool BNDebuggerShouldShowAdapterSettingsNextConnectToDebugServer(BNDebuggerController* controller);
+
+	DEBUGGER_FFI_API void BNDebuggerSetShowAdapterSettingsNextLaunch(BNDebuggerController* controller, bool value);
+	DEBUGGER_FFI_API void BNDebuggerSetShowAdapterSettingsNextAttach(BNDebuggerController* controller, bool value);
+	DEBUGGER_FFI_API void BNDebuggerSetShowAdapterSettingsNextConnect(BNDebuggerController* controller, bool value);
+	DEBUGGER_FFI_API void BNDebuggerSetShowAdapterSettingsNextConnectToDebugServer(BNDebuggerController* controller, bool value);
+
 	DEBUGGER_FFI_API bool BNDebuggerIsTTD(BNDebuggerController* controller);
 
 	// TTD Memory Analysis Functions

--- a/core/debuggercontroller.cpp
+++ b/core/debuggercontroller.cpp
@@ -3083,6 +3083,54 @@ bool DebuggerController::IsFirstAttach()
 }
 
 
+bool DebuggerController::ShouldShowAdapterSettingsNextLaunch()
+{
+	return m_showAdapterSettingsNextLaunch;
+}
+
+
+bool DebuggerController::ShouldShowAdapterSettingsNextAttach()
+{
+	return m_showAdapterSettingsNextAttach;
+}
+
+
+bool DebuggerController::ShouldShowAdapterSettingsNextConnect()
+{
+	return m_showAdapterSettingsNextConnect;
+}
+
+
+bool DebuggerController::ShouldShowAdapterSettingsNextConnectToDebugServer()
+{
+	return m_showAdapterSettingsNextConnectToDebugServer;
+}
+
+
+void DebuggerController::SetShowAdapterSettingsNextLaunch(bool value)
+{
+	m_showAdapterSettingsNextLaunch = value;
+}
+
+
+void DebuggerController::SetShowAdapterSettingsNextAttach(bool value)
+{
+	m_showAdapterSettingsNextAttach = value;
+}
+
+
+void DebuggerController::SetShowAdapterSettingsNextConnect(bool value)
+{
+	m_showAdapterSettingsNextConnect = value;
+}
+
+
+void DebuggerController::SetShowAdapterSettingsNextConnectToDebugServer(bool value)
+{
+	m_showAdapterSettingsNextConnectToDebugServer = value;
+}
+
+
 bool DebuggerController::IsTTD()
 {
 	if(!m_adapter)

--- a/core/debuggercontroller.h
+++ b/core/debuggercontroller.h
@@ -133,6 +133,11 @@ namespace BinaryNinjaDebugger {
 		bool m_firstConnectToDebugServer = true;
 		bool m_firstAttach = true;
 
+		bool m_showAdapterSettingsNextLaunch = true;
+		bool m_showAdapterSettingsNextAttach = true;
+		bool m_showAdapterSettingsNextConnect = true;
+		bool m_showAdapterSettingsNextConnectToDebugServer = true;
+
 		bool m_shouldAnnotateStackVariable = false;
 
 		void EventHandler(const DebuggerEvent& event);
@@ -399,6 +404,17 @@ namespace BinaryNinjaDebugger {
 		bool IsFirstConnect();
 		bool IsFirstConnectToDebugServer();
 		bool IsFirstAttach();
+
+		bool ShouldShowAdapterSettingsNextLaunch();
+		bool ShouldShowAdapterSettingsNextAttach();
+		bool ShouldShowAdapterSettingsNextConnect();
+		bool ShouldShowAdapterSettingsNextConnectToDebugServer();
+
+		void SetShowAdapterSettingsNextLaunch(bool value);
+		void SetShowAdapterSettingsNextAttach(bool value);
+		void SetShowAdapterSettingsNextConnect(bool value);
+		void SetShowAdapterSettingsNextConnectToDebugServer(bool value);
+
 		bool IsTTD();
 
 		// TTD Memory Analysis Methods

--- a/core/ffi.cpp
+++ b/core/ffi.cpp
@@ -1202,6 +1202,54 @@ bool BNDebuggerIsFirstAttach(BNDebuggerController* controller)
 }
 
 
+bool BNDebuggerShouldShowAdapterSettingsNextLaunch(BNDebuggerController* controller)
+{
+	return controller->object->ShouldShowAdapterSettingsNextLaunch();
+}
+
+
+bool BNDebuggerShouldShowAdapterSettingsNextAttach(BNDebuggerController* controller)
+{
+	return controller->object->ShouldShowAdapterSettingsNextAttach();
+}
+
+
+bool BNDebuggerShouldShowAdapterSettingsNextConnect(BNDebuggerController* controller)
+{
+	return controller->object->ShouldShowAdapterSettingsNextConnect();
+}
+
+
+bool BNDebuggerShouldShowAdapterSettingsNextConnectToDebugServer(BNDebuggerController* controller)
+{
+	return controller->object->ShouldShowAdapterSettingsNextConnectToDebugServer();
+}
+
+
+void BNDebuggerSetShowAdapterSettingsNextLaunch(BNDebuggerController* controller, bool value)
+{
+	controller->object->SetShowAdapterSettingsNextLaunch(value);
+}
+
+
+void BNDebuggerSetShowAdapterSettingsNextAttach(BNDebuggerController* controller, bool value)
+{
+	controller->object->SetShowAdapterSettingsNextAttach(value);
+}
+
+
+void BNDebuggerSetShowAdapterSettingsNextConnect(BNDebuggerController* controller, bool value)
+{
+	controller->object->SetShowAdapterSettingsNextConnect(value);
+}
+
+
+void BNDebuggerSetShowAdapterSettingsNextConnectToDebugServer(BNDebuggerController* controller, bool value)
+{
+	controller->object->SetShowAdapterSettingsNextConnectToDebugServer(value);
+}
+
+
 bool BNDebuggerIsTTD(BNDebuggerController* controller)
 {
 	return controller->object->IsTTD();

--- a/ui/adaptersettings.cpp
+++ b/ui/adaptersettings.cpp
@@ -24,7 +24,7 @@ using namespace BinaryNinja;
 using namespace std;
 
 AdapterSettingsDialog::AdapterSettingsDialog(QWidget* parent, DbgRef<DebuggerController> controller, const std::string& highlightGroup) :
-	QDialog(), m_controller(controller)
+	QDialog(), m_controller(controller), m_highlightGroup(highlightGroup)
 {
 	setWindowTitle("Debug Adapter Settings");
 	setAttribute(Qt::WA_DeleteOnClose);
@@ -78,12 +78,16 @@ AdapterSettingsDialog::AdapterSettingsDialog(QWidget* parent, DbgRef<DebuggerCon
 		QHBoxLayout* buttonLayout = new QHBoxLayout;
 		buttonLayout->setContentsMargins(0, 0, 0, 0);
 
+		m_useSameSettingsCheckbox = new QCheckBox("Use same settings next time");
+		m_useSameSettingsCheckbox->setChecked(true);
+
 		QPushButton* cancelButton = new QPushButton("Cancel");
 		connect(cancelButton, &QPushButton::clicked, [&]() { reject(); });
 		QPushButton* acceptButton = new QPushButton("Accept");
 		connect(acceptButton, &QPushButton::clicked, [&]() { apply(); });
 		acceptButton->setDefault(true);
 
+		buttonLayout->addWidget(m_useSameSettingsCheckbox);
 		buttonLayout->addStretch(1);
 		buttonLayout->addWidget(cancelButton);
 		buttonLayout->addSpacing(10);
@@ -139,5 +143,17 @@ QWidget* AdapterSettingsDialog::getWidgetForAdapter(const QString& adapter)
 
 void AdapterSettingsDialog::apply()
 {
+	if (m_useSameSettingsCheckbox)
+	{
+		bool showAgain = !m_useSameSettingsCheckbox->isChecked();
+		if (m_highlightGroup == "launch")
+			m_controller->SetShowAdapterSettingsNextLaunch(showAgain);
+		else if (m_highlightGroup == "attach")
+			m_controller->SetShowAdapterSettingsNextAttach(showAgain);
+		else if (m_highlightGroup == "connect")
+			m_controller->SetShowAdapterSettingsNextConnect(showAgain);
+		else if (m_highlightGroup == "debug_server")
+			m_controller->SetShowAdapterSettingsNextConnectToDebugServer(showAgain);
+	}
 	accept();
 }

--- a/ui/adaptersettings.h
+++ b/ui/adaptersettings.h
@@ -42,6 +42,8 @@ private:
 	QStackedWidget* m_stack;
 	QMap<QString, QWidget*> m_viewMap;
 	QLabel* m_noSettingsLabel;
+	QCheckBox* m_useSameSettingsCheckbox = nullptr;
+	std::string m_highlightGroup;
 
 	QWidget* getWidgetForAdapter(const QString& adapter);
 

--- a/ui/controlswidget.cpp
+++ b/ui/controlswidget.cpp
@@ -267,7 +267,7 @@ void DebugControlsWidget::performLaunch()
 		return;
 
 	bool firstLaunch = m_controller->IsFirstLaunch();
-	if (firstLaunch)
+	if (firstLaunch || m_controller->ShouldShowAdapterSettingsNextLaunch())
 	{
 		auto adapterSettings = new AdapterSettingsDialog(this, m_controller, "launch");
 		if (adapterSettings->exec() != QDialog::Accepted)

--- a/ui/ui.cpp
+++ b/ui/ui.cpp
@@ -552,7 +552,7 @@ void GlobalDebuggerUI::SetupMenu(UIContext* context)
 					return;
 
 				bool firstLaunch = controller->IsFirstLaunch();
-                if (firstLaunch)
+                if (firstLaunch || controller->ShouldShowAdapterSettingsNextLaunch())
                 {
                 	auto adapterSettings = new AdapterSettingsDialog(context->mainWindow(), controller, "launch");
                 	if (adapterSettings->exec() != QDialog::Accepted)
@@ -848,7 +848,7 @@ void GlobalDebuggerUI::SetupMenu(UIContext* context)
 				if (!controller)
 					return;
 
-				if (controller->IsFirstAttach())
+				if (controller->IsFirstAttach() || controller->ShouldShowAdapterSettingsNextAttach())
 				{
 					auto adapterSettings = new AdapterSettingsDialog(context->mainWindow(), controller, "attach");
 					if (adapterSettings->exec() != QDialog::Accepted)
@@ -1063,7 +1063,7 @@ void GlobalDebuggerUI::SetupMenu(UIContext* context)
 				if (!controller)
 					return;
 
-                if (controller->IsFirstConnectToDebugServer())
+                if (controller->IsFirstConnectToDebugServer() || controller->ShouldShowAdapterSettingsNextConnectToDebugServer())
                 {
                 	auto adapterSettings = new AdapterSettingsDialog(context->mainWindow(), controller, "debug_server");
                 	if (adapterSettings->exec() != QDialog::Accepted)
@@ -1118,7 +1118,7 @@ void GlobalDebuggerUI::SetupMenu(UIContext* context)
 				if (!controller)
 					return;
 
-				if (controller->IsFirstConnect())
+				if (controller->IsFirstConnect() || controller->ShouldShowAdapterSettingsNextConnect())
 				{
 					auto adapterSettings = new AdapterSettingsDialog(context->mainWindow(), controller, "connect");
 					if (adapterSettings->exec() != QDialog::Accepted)


### PR DESCRIPTION
Adds a "Use same settings next time" checkbox to the adapter settings (enabled on default) dialog that will skip the dialog silently if checked.

Closes #973 