### PR TITLE
Add assertions within DebuggerMemory::ReadMemory

### DIFF
--- a/core/debuggerfileaccessor.cpp
+++ b/core/debuggerfileaccessor.cpp
@@ -15,6 +15,8 @@ limitations under the License.
 */
 
 #include "debuggerfileaccessor.h"
+
+#include "base/assertions.h"
 #include "debuggercontroller.h"
 
 using namespace BinaryNinja;
@@ -54,6 +56,7 @@ uint64_t DebuggerFileAccessor::GetLength() const
 size_t DebuggerFileAccessor::Read(void *dest, uint64_t offset, size_t len)
 {
 	DataBuffer buffer = m_controller->ReadMemory(offset, len);
+	BN_RELEASE_ASSERT(buffer.GetLength() <= len);
 	memcpy(dest, buffer.GetData(), buffer.GetLength());
 
 	return buffer.GetLength();

--- a/core/debuggerstate.cpp
+++ b/core/debuggerstate.cpp
@@ -18,6 +18,7 @@ limitations under the License.
 #include <thread>
 #include <utility>
 #include <filesystem>
+#include "base/assertions.h"
 #include "lowlevelilinstruction.h"
 #include "mediumlevelilinstruction.h"
 #include "highlevelilinstruction.h"
@@ -1260,6 +1261,7 @@ DataBuffer DebuggerMemory::ReadBlock(uint64_t block)
 	{
 		// The cache is old and the target is stopped, try to update the cache value
 		DataBuffer buffer = m_state->GetAdapter()->ReadMemory(block, 0x100);
+		BN_RELEASE_ASSERT(buffer.GetLength() <= 0x100);
 		if (buffer.GetLength() > 0)
 		{
 			// Successfully updated
@@ -1328,6 +1330,7 @@ DataBuffer DebuggerMemory::ReadMemory(uint64_t offset, size_t len)
 		}
 		result.Append(cached);
 	}
+	BN_RELEASE_ASSERT(result.GetLength() <= len);
 	return result;
 }
 


### PR DESCRIPTION
These assertions are enabled in release builds in an attempt to narrow down the cause of
https://github.com/Vector35/binaryninja/issues/1447. They can be converted to debug-only assertions or removed once the cause is understood and fixed.