### PR TITLE
Fix crash in CorelliumAdapter::BreakInto when m_rspConnector is null

### DIFF
--- a/core/adapters/corelliumadapter.cpp
+++ b/core/adapters/corelliumadapter.cpp
@@ -789,6 +789,9 @@ std::string CorelliumAdapter::GetTargetArchitecture()
 
 bool CorelliumAdapter::BreakInto()
 {
+	if (!m_isTargetRunning || !m_rspConnector)
+		return false;
+
     char var = '\x03';
     this->m_rspConnector->SendRaw(RspData(&var, sizeof(var)));
     m_isTargetRunning = false;


### PR DESCRIPTION
## Summary
- Adds the same `!m_isTargetRunning || !m_rspConnector` guard to `CorelliumAdapter::BreakInto` that `GdbAdapter::BreakInto` already has, preventing a null-pointer dereference in `RspConnector::SendRaw`.
- Resolves the Sentry-reported crash `EXCEPTION_ACCESS_VIOLATION_READ / 0x50` at `rspconnector.cpp:223` reached via `CorelliumAdapter::BreakInto`.

Fixes #1066
Fixes BINARYNINJA-3X

## Sentry context
- 23 events since 2026-04-15 across many distinct users (Belgium, Saudi Arabia, US, Vietnam, France, China, macOS once)
- 22/23 events on Free edition, 1 on Personal, none on Commercial/Enterprise
- 22/23 on Windows (heavily Windows 11 25H2 / build 26200), 1 on macOS
- All on `binaryninja@5.3.9434`
- Likely scenario: users pick "Corellium" from the adapter dropdown without ever connecting, then click Pause — `m_rspConnector` is still null and the unconditional `SendRaw` crashes. The `0x50` faulting address is consistent with a null `this` deref reading a field at offset 0x50 inside `RspConnector`.

## Test plan
- [ ] Build the debugger and confirm Corellium adapter still attaches/breaks normally on a live target.
- [ ] Select the Corellium adapter without connecting, click Pause, confirm no crash (previously crashed, now should just no-op).

🤖 Generated with [Claude Code](https://claude.com/claude-code)