### PR TITLE
Fix null deref in EsrevenAdapter::GetProcessList

### DIFF
--- a/core/adapters/esrevenadapter.cpp
+++ b/core/adapters/esrevenadapter.cpp
@@ -2491,7 +2491,7 @@ void EsrevenAdapter::HandleAsyncPacket(const RspData& data)
 
 std::vector<DebugProcess> EsrevenAdapter::GetProcessList()
 {
-	if (m_isTargetRunning)
+	if (m_isTargetRunning || !m_rspConnector)
 		return {};
 
 	// Use the custom reven list-processes packet


### PR DESCRIPTION
## Summary
- `EsrevenAdapter::GetProcessList` dereferenced `m_rspConnector` unconditionally; mirror the `!m_rspConnector` guard that every other method in this adapter already has.
- Hit via the Attach Process dialog (`controlswidget.cpp:358` → `attachprocess.cpp:401` → `DebuggerController::GetProcessList` → `EsrevenAdapter::GetProcessList`), so any user opening that dialog without first connecting to a Reven backend crashes.

Fixes #1071
Fixes BINARYNINJA-61

## Sentry context
- 1 event so far (first seen 2026-05-01), single user in the US on macOS 26.5.0 arm64
- `bn.edition=Free`, `release=binaryninja@5.3.9434` — same demographic pattern as #1066: a free user exploring an adapter that needs a server-side backend they don't have
- Crash signature `EXC_BAD_ACCESS / KERN_INVALID_ADDRESS / 0x0` inside `unique_lock` constructing on the null `RspConnector::m_socketLock`

## Note on the broader race
This is the same shape of bug as the one PR #1075 addresses across all three RSP adapters via `std::shared_ptr` lifetime management. This narrower patch lands a minimal fix on `dev` so the user-visible crash stops without waiting on the larger refactor. If #1075 merges first, this change is already subsumed by it and the PR can be closed.

## Test plan
- [ ] Build the debugger and open the Attach Process dialog on the Reven adapter without connecting — confirm it returns an empty list cleanly instead of crashing.
- [ ] Connect to a Reven backend and confirm the process list still populates normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)