### PR TITLE
Add missing m_rspConnector null checks in WriteMemory and TTD call query

### DIFF
--- a/core/adapters/esrevenadapter.cpp
+++ b/core/adapters/esrevenadapter.cpp
@@ -1129,7 +1129,7 @@ DataBuffer EsrevenAdapter::ReadMemory(std::uintptr_t address, std::size_t size)
 
 bool EsrevenAdapter::WriteMemory(std::uintptr_t address, const DataBuffer& buffer)
 {
-    if (m_isTargetRunning)
+    if (m_isTargetRunning || !m_rspConnector)
         return false;
 
     size_t size = buffer.GetLength();
@@ -2925,6 +2925,9 @@ std::vector<TTDCallEvent> EsrevenAdapter::GetTTDCallsForSymbols(const std::strin
 		LogError("No symbols provided for TTD calls query");
 		return events;
 	}
+
+	if (!m_rspConnector)
+		return events;
 
 	// Get settings
 	auto adapterSettings = GetAdapterSettings();

--- a/core/adapters/gdbadapter.cpp
+++ b/core/adapters/gdbadapter.cpp
@@ -725,7 +725,7 @@ DataBuffer GdbAdapter::ReadMemory(std::uintptr_t address, std::size_t size)
 
 bool GdbAdapter::WriteMemory(std::uintptr_t address, const DataBuffer& buffer)
 {
-    if (m_isTargetRunning)
+    if (m_isTargetRunning || !m_rspConnector)
         return false;
 
     size_t size = buffer.GetLength();


### PR DESCRIPTION
## Summary
- Three publicly-callable RSP-adapter methods deref'd `m_rspConnector` while every sibling method in the same class already null-checks it. Mirror the existing guard so they return an empty result instead of crashing.
- Same shape as #1066 and #1071: a user selects the adapter from the UI without connecting to a backend, triggers an action, and the unconditional deref crashes.

Sites fixed:
- `GdbAdapter::WriteMemory` (gdbadapter.cpp:726)
- `EsrevenAdapter::WriteMemory` (esrevenadapter.cpp:1130)
- `EsrevenAdapter::GetTTDCallsForSymbols` (esrevenadapter.cpp:2919)

## Context
No Sentry crashes filed for these specific methods yet, but the pre-conditions for hitting them are the same as the BINARYNINJA-3X and BINARYNINJA-61 reports, so these are latent versions of the same bug.

## Relationship to other PRs
PR #1075 (the structural shared_ptr lifetime fix) subsumes these as a side effect, but this PR lands the narrow guards on `dev` immediately without waiting on the larger review. If #1075 merges first, this is redundant and can be closed.

## Test plan
- [ ] Build the debugger; select the Gdb adapter without connecting and exercise a memory write via API — confirm no crash.
- [ ] Same for the Esreven adapter (memory write and a TTD calls query).

🤖 Generated with [Claude Code](https://claude.com/claude-code)