### PR TITLE
Fix null deref in DbgEngAdapter::ReadMemory and WriteMemory

### DIFF
--- a/core/adapters/dbgengadapter.cpp
+++ b/core/adapters/dbgengadapter.cpp
@@ -2176,6 +2176,9 @@ bool DbgEngAdapter::SupportFeature(DebugAdapterCapacity feature)
 
 DataBuffer DbgEngAdapter::ReadMemory(std::uintptr_t address, std::size_t size)
 {
+	if (!m_debugDataSpaces)
+		return {};
+
 	const auto source = std::make_unique<std::uint8_t[]>(size);
 
 	unsigned long bytesRead {};
@@ -2189,6 +2192,9 @@ DataBuffer DbgEngAdapter::ReadMemory(std::uintptr_t address, std::size_t size)
 
 bool DbgEngAdapter::WriteMemory(std::uintptr_t address, const DataBuffer& buffer)
 {
+	if (!m_debugDataSpaces)
+		return false;
+
 	unsigned long bytes_written {};
 	return this->m_debugDataSpaces->WriteVirtual(address, const_cast<void*>(buffer.GetData()), (ULONG)buffer.GetLength(), &bytes_written) == S_OK
 		&& bytes_written == buffer.GetLength();


### PR DESCRIPTION
## Summary
- `DbgEngAdapter::ReadMemory` and `WriteMemory` dereferenced `m_debugDataSpaces` without a null check; add the same kind of guard that the rest of the adapter already uses (e.g. `ExecStatus()` null-checks `m_debugControl`).
- Per the Sentry trace, the crash is reached from the breakpoint-toggle button: `DebugControlsWidget::toggleBreakpoint` → `DebuggerController::AddBreakpoint` → `DebuggerBreakpoints::ContainsAbsolute` → `DbgEngAdapter::ReadMemory`. That path runs before `m_debugDataSpaces` is populated by a `Connect`/`Attach`, so the field is null and the call deref's it.

Fixes #1070
Fixes BINARYNINJA-5Z

## Sentry context
- 1 event so far (first seen 2026-05-01), single user in Australia on Windows 11 25H2 (build 26200) x86_64
- `bn.edition=Free`, `release=binaryninja@5.3.9434` — same Free-edition-user-tries-an-adapter-without-connecting demographic as #1066, #1071
- Crash signature `EXCEPTION_ACCESS_VIOLATION_READ / 0x0` at `dbgengadapter.cpp:2182`, classic null `this->m_debugDataSpaces->ReadVirtual(...)`

## Test plan
- [ ] Build the debugger on Windows, select DbgEng adapter without launching/attaching, click Toggle Breakpoint — confirm no crash (previously crashed inside `ContainsAbsolute`'s ReadMemory probe).
- [ ] Launch a process and confirm Read/Write memory still work normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)