### PR TITLE
Catch BinaryReader exceptions when reading stack variable parameters

### DIFF
--- a/ui/debuggerinfowidget.cpp
+++ b/ui/debuggerinfowidget.cpp
@@ -92,9 +92,18 @@ std::vector<DebuggerInfoEntry> DebuggerInfoTable::getInfoForLLILCalls(LowLevelIL
 			offset -= arch->GetAddressSize();
 			auto realOffset = offset + m_debugger->StackPointer();
 
-			BinaryReader reader(m_data);
-			reader.Seek(realOffset);
-			auto value = reader.ReadPointer();
+			uint64_t value = 0;
+			try
+			{
+				BinaryReader reader(m_data);
+				reader.Seek(realOffset);
+				value = reader.ReadPointer();
+			}
+			catch (...)
+			{
+				// realOffset is outside the binary view; skip this entry
+				break;
+			}
 			auto hints = m_debugger->GetAddressInformation(value);
 
 			auto paramName = func->GetVariableName(param);
@@ -311,9 +320,18 @@ std::vector<DebuggerInfoEntry> DebuggerInfoTable::getInfoForMLILCalls(MediumLeve
 			offset -= arch->GetAddressSize();
 			auto realOffset = offset + m_debugger->StackPointer();
 
-			BinaryReader reader(m_data);
-			reader.Seek(realOffset);
-			auto value = reader.ReadPointer();
+			uint64_t value = 0;
+			try
+			{
+				BinaryReader reader(m_data);
+				reader.Seek(realOffset);
+				value = reader.ReadPointer();
+			}
+			catch (...)
+			{
+				// realOffset is outside the binary view; skip this entry
+				break;
+			}
 			auto hints = m_debugger->GetAddressInformation(value);
 
 			auto paramName = func->GetVariableName(param);
@@ -484,9 +502,18 @@ std::vector<DebuggerInfoEntry> DebuggerInfoTable::getInfoForHLILCalls(HighLevelI
 			offset -= arch->GetAddressSize();
 			auto realOffset = offset + m_debugger->StackPointer();
 
-			BinaryReader reader(m_data);
-			reader.Seek(realOffset);
-			auto value = reader.ReadPointer();
+			uint64_t value = 0;
+			try
+			{
+				BinaryReader reader(m_data);
+				reader.Seek(realOffset);
+				value = reader.ReadPointer();
+			}
+			catch (...)
+			{
+				// realOffset is outside the binary view; skip this entry
+				break;
+			}
 			auto hints = m_debugger->GetAddressInformation(value);
 
 			auto paramName = func->GetVariableName(param);


### PR DESCRIPTION
## Summary
- `DebuggerInfoTable::getInfoFor{LLIL,MLIL,HLIL}Calls` each compute a stack offset (`stack pointer + parameter slot`) and pass it to `BinaryReader::Seek` + `ReadPointer` to show the parameter value next to a call in the info table. If the computed offset falls outside the BinaryView's range, `ReadPointer` throws `ReadException`. The caller is invoked from a Qt slot with no handler up the stack, so the unhandled C++ exception terminates the process.
- Wrap each read in a try/catch and skip the parameter entry on failure. The widget still renders the remaining parameters normally. Applied to all three IL variants since they share the identical pattern (the Sentry-reported one is HLIL, the others are latent).

Fixes #1068
Fixes BINARYNINJA-47

## Sentry context
- 1 event so far (first seen 2026-04-16), single user in the Czech Republic on Windows 11 x86_64
- `bn.edition=Free`, `release=binaryninja@5.3.9434` — same Free-edition demographic as the recent crash batch (#1066, #1070, #1071)
- Crash signature: unhandled C++ exception (`_CxxThrowException`) originating from `BinaryReader::ReadLEPointer` reached via `DebuggerInfoTable::getInfoForHLILCalls`

## Test plan
- [ ] Open the Debugger Info widget on a target, exercise calls whose stack parameters land in valid mapped regions — confirm parameter values still display.
- [ ] Exercise the bad path: hover/click a call where the computed stack offset is outside the BinaryView (e.g. very early in `main` before the stack is established, or with a custom raw view) — confirm the widget renders without crashing and just omits the unreadable entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)