### PR TITLE
Join leftover debug thread in WindowsNativeAdapter destructor

### DIFF
--- a/core/adapters/windowsnativeadapter.cpp
+++ b/core/adapters/windowsnativeadapter.cpp
@@ -111,6 +111,12 @@ WindowsNativeAdapter::~WindowsNativeAdapter()
 {
 	if (m_activelyDebugging)
 		Quit();
+
+	// If the target exited on its own, HandleExitProcess cleared m_activelyDebugging and the
+	// debug loop returned, but nobody joined the thread. Destroying a joinable std::thread
+	// calls std::terminate, so join here to cover that path.
+	if (m_debugThread.joinable())
+		m_debugThread.join();
 }
 
 


### PR DESCRIPTION
## Summary
- The destructor only called `Quit()` when `m_activelyDebugging` was true, but the natural target-exit path clears `m_activelyDebugging` from inside the debug thread itself (`HandleExitProcess` at windowsnativeadapter.cpp:1022) before the DebugLoop returns. After that, nobody joins `m_debugThread` (both `Detach` and `Quit` early-return on `!m_activelyDebugging`), so when the adapter is later destroyed, the still-joinable `std::thread` member's destructor calls `std::terminate`.
- Always check `joinable()` in the destructor and join. The join is a no-op in the common case (the thread already returned), and correctly blocks when there's still work in flight.

Fixes #1065
Fixes BINARYNINJA-3Q

## Sentry context
- 2 events so far (first seen 2026-04-14, last 2026-04-29), distinct users
- Both on Windows 11 25H2 x86_64, releases `binaryninja@5.3.9434`
- `bn.edition=Personal` on the latest event - this one isn't a Free-user-explores-adapter pattern; it's the natural "launch process, let it run to completion, close project" flow
- Stack trace: `~DebuggerController` → `~DebuggerState` → `~WindowsNativeAdapter` → `std::thread::~thread` → `terminate` → `abort` → crashpad

## Test plan
- [ ] Launch a process that exits quickly (e.g. `cmd /c exit 0`) and let it run to completion. Then close the binary view / project. Confirm no crash on shutdown.
- [ ] Normal launch → manual stop → close path still works (Quit's join is the active one in that case).
- [ ] Attach → process exits naturally → close path also clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)