### PR TITLE
Narrow catch blocks in DebuggerInfoTable to ReadException

### DIFF
--- a/ui/debuggerinfowidget.cpp
+++ b/ui/debuggerinfowidget.cpp
@@ -99,7 +99,7 @@ std::vector<DebuggerInfoEntry> DebuggerInfoTable::getInfoForLLILCalls(LowLevelIL
 				reader.Seek(realOffset);
 				value = reader.ReadPointer();
 			}
-			catch (...)
+			catch (const ReadException&)
 			{
 				// realOffset is outside the binary view; skip this entry
 				break;
@@ -327,7 +327,7 @@ std::vector<DebuggerInfoEntry> DebuggerInfoTable::getInfoForMLILCalls(MediumLeve
 				reader.Seek(realOffset);
 				value = reader.ReadPointer();
 			}
-			catch (...)
+			catch (const ReadException&)
 			{
 				// realOffset is outside the binary view; skip this entry
 				break;
@@ -509,7 +509,7 @@ std::vector<DebuggerInfoEntry> DebuggerInfoTable::getInfoForHLILCalls(HighLevelI
 				reader.Seek(realOffset);
 				value = reader.ReadPointer();
 			}
-			catch (...)
+			catch (const ReadException&)
 			{
 				// realOffset is outside the binary view; skip this entry
 				break;


### PR DESCRIPTION
## Summary
- Follow-up to #1079: replace `catch (...)` with `catch (const ReadException&)` in the three try blocks added around `BinaryReader::Seek` + `ReadPointer`.
- `BinaryNinja::ReadException` (binaryninjaapi.h:8780) is the specific exception both APIs throw, so the narrow catch documents intent and lets unrelated failures (allocation errors, etc.) propagate where they can be diagnosed.

## Test plan
- [ ] Same as #1079 — same code paths, just a tighter exception type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)