### PR TITLE
Guard against SBPlatform::GetTriple returning nullptr

### DIFF
--- a/core/adapters/lldbadapter.cpp
+++ b/core/adapters/lldbadapter.cpp
@@ -1573,7 +1573,11 @@ std::string LldbAdapter::GetTargetArchitecture()
 {
 	SBPlatform platform = m_target.GetPlatform();
 	//	"arm64-apple-macosx" ==> "arm64"
-	std::string triple(platform.GetTriple());
+	const char* tripleStr = platform.GetTriple();
+	if (tripleStr == nullptr)
+		return "";
+
+	std::string triple(tripleStr);
 	auto position = triple.find('-');
 	if (position == std::string::npos)
 		return "";

--- a/core/adapters/lldbadapter.cpp
+++ b/core/adapters/lldbadapter.cpp
@@ -1420,7 +1420,9 @@ DebugRegister LldbAdapter::ReadRegister(const std::string& name)
 		for (uint32_t j = 0; j < numRegs; j++)
 		{
 			SBValue reg = regGroupInfo.GetChildAtIndex(j);
-			if (name == reg.GetName())
+			// SBValue::GetName() can return NULL; comparing a std::string against a nullptr is undefined behavior
+			const char* regName = reg.GetName();
+			if (regName != nullptr && name == regName)
 				// TODO: register width and internal index
 				return DebugRegister(name, SBValueToUint512(reg), 0, 0);
 		}
@@ -1558,7 +1560,9 @@ std::vector<DebugModule> LldbAdapter::GetModuleList()
 		char path[1024];
 		size_t len = fileSpec.GetPath(path, 1024);
 		m.m_name = std::string(path, len);
-		m.m_short_name = fileSpec.GetFilename();
+		// SBFileSpec::GetFilename() can return NULL; constructing a std::string from a nullptr is undefined behavior
+		if (const char* shortName = fileSpec.GetFilename())
+			m.m_short_name = shortName;
 		SBAddress headerAddress = module.GetObjectFileHeaderAddress();
 		m.m_address = headerAddress.GetLoadAddress(m_target);
 		m.m_size = GetModuleHighestAddress(module, m_target) - m.m_address;
@@ -2401,5 +2405,7 @@ void LldbAdapter::GenerateDefaultAdapterSettings(BinaryView* data)
 	adapterSettings->UpdateProperty("debugServer.platform", "enum", platforms);
 
 	auto platform = m_debugger.GetSelectedPlatform();
-	adapterSettings->UpdateProperty("debugServer.platform", "default", platform.GetName());
+	// SBPlatform::GetName() can return NULL; constructing a std::string from a nullptr is undefined behavior
+	const char* platformName = platform.GetName();
+	adapterSettings->UpdateProperty("debugServer.platform", "default", platformName ? platformName : "");
 }

--- a/core/adapters/lldbcoredumpadapter.cpp
+++ b/core/adapters/lldbcoredumpadapter.cpp
@@ -534,7 +534,9 @@ DebugRegister LldbCoreDumpAdapter::ReadRegister(const std::string& name)
 		for (uint32_t j = 0; j < numRegs; j++)
 		{
 			SBValue reg = regGroupInfo.GetChildAtIndex(j);
-			if (name == reg.GetName())
+			// SBValue::GetName() can return NULL; comparing a std::string against a nullptr is undefined behavior
+			const char* regName = reg.GetName();
+			if (regName != nullptr && name == regName)
 				// TODO: register width and internal index
 				return DebugRegister(name, reg.GetValueAsUnsigned(), 0, 0);
 		}
@@ -606,7 +608,9 @@ std::vector<DebugModule> LldbCoreDumpAdapter::GetModuleList()
 		char path[1024];
 		size_t len = fileSpec.GetPath(path, 1024);
 		m.m_name = std::string(path, len);
-		m.m_short_name = fileSpec.GetFilename();
+		// SBFileSpec::GetFilename() can return NULL; constructing a std::string from a nullptr is undefined behavior
+		if (const char* shortName = fileSpec.GetFilename())
+			m.m_short_name = shortName;
 		SBAddress headerAddress = module.GetObjectFileHeaderAddress();
 		m.m_address = headerAddress.GetLoadAddress(m_target);
 		m.m_size = GetModuleHighestAddress(module, m_target) - m.m_address;
@@ -621,7 +625,11 @@ std::string LldbCoreDumpAdapter::GetTargetArchitecture()
 {
 	SBPlatform platform = m_target.GetPlatform();
 	//	"arm64-apple-macosx" ==> "arm64"
-	std::string triple(platform.GetTriple());
+	const char* tripleStr = platform.GetTriple();
+	if (tripleStr == nullptr)
+		return "";
+
+	std::string triple(tripleStr);
 	auto position = triple.find('-');
 	if (position == std::string::npos)
 		return "";


### PR DESCRIPTION
## Summary

`SBPlatform::GetTriple` [can return `nullptr` in some situations](https://github.com/llvm/llvm-project/blob/17449ef9b7296da8a10d46410c62f16fde98bcd6/lldb/source/API/SBPlatform.cpp#L416-L429). Constructing a `std::string` from (or comparing one against) a `nullptr` `const char*` is undefined behavior; on Windows it crashes with an `EXCEPTION_ACCESS_VIOLATION_READ`. The reported crash (#1096) was in `LldbAdapter::GetTargetArchitecture`.

While fixing that, I audited the LLDB adapter code for the same pattern and guarded the other unsafe `const char*` returns:

- **`GetTargetArchitecture`** (`LldbAdapter` and `LldbCoreDumpAdapter`) — `SBPlatform::GetTriple()` constructed a `std::string` directly. *(the crash in #1096)*
- **`ReadRegister`** (`LldbAdapter` and `LldbCoreDumpAdapter`) — compared a `std::string` against `SBValue::GetName()`, which the codebase already documents can return `NULL`.
- **`GetModuleList`** (`LldbAdapter` and `LldbCoreDumpAdapter`) — assigned `SBFileSpec::GetFilename()` directly to a `std::string` member.
- **Platform settings** (`LldbAdapter`) — passed `SBPlatform::GetName()` unguarded into a settings update.

In each case a null result now yields an empty string (matching existing fallback behavior) instead of dereferencing the null pointer.

Fixes #1096

🤖 Generated with [Claude Code](https://claude.com/claude-code)