### PR TITLE
Erase deleted controllers from state.controllers instead of nulling them

### DIFF
--- a/core/debuggercontroller.cpp
+++ b/core/debuggercontroller.cpp
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 #include "debuggercontroller.h"
+#include <algorithm>
 #include <thread>
 #include <fstream>
 #include "base/assertions.h"
@@ -1912,11 +1913,10 @@ void DebuggerController::DeleteController(BinaryViewRef data)
 {
 	auto& state = GetControllerState();
 	std::lock_guard<std::mutex> lock(state.mutex);
-	for (auto& c : state.controllers)
-	{
-		if (c && c->GetFile() == data->GetFile())
-			c = nullptr;
-	}
+	state.controllers.erase(
+		std::remove_if(state.controllers.begin(), state.controllers.end(),
+			[&](const DbgRef<DebuggerController>& c) { return c && c->GetFile() == data->GetFile(); }),
+		state.controllers.end());
 }
 
 
@@ -1967,11 +1967,10 @@ void DebuggerController::DeleteController(FileMetadataRef file)
 {
 	auto& state = GetControllerState();
 	std::lock_guard<std::mutex> lock(state.mutex);
-	for (auto& c : state.controllers)
-	{
-		if (c && c->GetFile() == file)
-			c = nullptr;
-	}
+	state.controllers.erase(
+		std::remove_if(state.controllers.begin(), state.controllers.end(),
+			[&](const DbgRef<DebuggerController>& c) { return c && c->GetFile() == file; }),
+		state.controllers.end());
 }
 
 


### PR DESCRIPTION
Fixes #1052.

`DebuggerController::DeleteController` (both the `BinaryViewRef` and `FileMetadataRef` overloads) set matching entries in `state.controllers` to `nullptr` rather than removing them. This left dead null slots in the vector that accumulate for the entire process lifetime and forced every other accessor (`GetController`, `ControllerExists`, ...) to null-check each element.

This switches both overloads to the erase-remove idiom so deleted controllers are actually dropped from the vector. Ref-count behavior is unchanged — erasing the `DbgRef` releases the same reference the `nullptr` assignment did, all under the existing `state.mutex`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)