### PR TITLE
Null-check UIContext in DebuggerUI::CreateForViewFrame

### DIFF
--- a/ui/ui.cpp
+++ b/ui/ui.cpp
@@ -2078,6 +2078,9 @@ DebuggerUI* DebuggerUI::CreateForViewFrame(ViewFrame* frame)
 		return nullptr;
 
 	UIContext* context = UIContext::contextForWidget(frame);
+	if (!context)
+		return nullptr;
+
 	BinaryViewRef data = frame->getCurrentBinaryView();
 	if (!data)
 		return nullptr;


### PR DESCRIPTION
## Summary

`UIContext::contextForWidget` can return null, but in `DebuggerUI::CreateForViewFrame` the result was passed directly into `DebuggerUI`'s constructor, where it is assumed to be non-null. This leads to a crash (`EXC_BAD_ACCESS` at address 0x0) in `DebuggerUI::updateUI`.

This adds an early null check for the context, matching how other callers of `UIContext::contextForWidget` in the debugger already null-check the result before use.

Fixes #1094

## Test plan

- Build the debugger UI plugin.
- Crash is reported via Sentry ([BINARYNINJA-8Y](https://vector35.sentry.io/issues/7502764585/)) and the null-deref path is now guarded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)