### PR TITLE
Resolve strdup memory leak with GetPathBaseName

### DIFF
--- a/core/debugadapter.cpp
+++ b/core/debugadapter.cpp
@@ -16,12 +16,10 @@ limitations under the License.
 
 #include <binaryninjacore.h>
 #include <binaryninjaapi.h>
+#include <filesystem>
 #include <lowlevelilinstruction.h>
 #include <mediumlevelilinstruction.h>
 #include <highlevelilinstruction.h>
-#ifndef WIN32
-	#include "libgen.h"
-#endif
 #include "debugadapter.h"
 #include "debuggercontroller.h"
 
@@ -80,7 +78,8 @@ std::string DebugModule::GetPathBaseName(const std::string& path)
 	_splitpath_s(path.c_str(), NULL, 0, NULL, 0, baseName, MAX_PATH, ext, MAX_PATH);
 	return std::string(baseName) + std::string(ext);
 #else
-	return basename(strdup(path.c_str()));
+	std::filesystem::path fs_path(path);
+	return fs_path.stem();
 #endif
 }
 

--- a/core/debugadapter.cpp
+++ b/core/debugadapter.cpp
@@ -79,7 +79,7 @@ std::string DebugModule::GetPathBaseName(const std::string& path)
 	return std::string(baseName) + std::string(ext);
 #else
 	std::filesystem::path fs_path(path);
-	return fs_path.stem();
+	return fs_path.filename().string();
 #endif
 }
 

--- a/core/debuggercommon.h
+++ b/core/debuggercommon.h
@@ -15,11 +15,12 @@ limitations under the License.
 */
 
 #pragma once
+#include <cstdint>
+#include <filesystem>
 #include <string.h>
 #include <optional>
-#ifndef WIN32
-	#include "libgen.h"
-#endif
+#include <string>
+#include <vector>
 
 namespace BinaryNinjaDebugger {
 	struct ModuleNameAndOffset
@@ -63,7 +64,8 @@ namespace BinaryNinjaDebugger {
 			_splitpath_s(path.c_str(), NULL, 0, NULL, 0, baseName, MAX_PATH, ext, MAX_PATH);
 			return std::string(baseName) + std::string(ext);
 #else
-			return basename(strdup(path.c_str()));
+			std::filesystem::path fs_path(path);
+			return fs_path.stem();
 #endif
 		}
 

--- a/core/debuggercommon.h
+++ b/core/debuggercommon.h
@@ -65,7 +65,7 @@ namespace BinaryNinjaDebugger {
 			return std::string(baseName) + std::string(ext);
 #else
 			std::filesystem::path fs_path(path);
-			return fs_path.stem();
+			return fs_path.filename().string();
 #endif
 		}
 


### PR DESCRIPTION
Whenever `DebugModule::GetPathBaseName` and `ModuleNameAndOffset::GetPathBaseName` is called a memory leak the size of the c string version of the path parameter is created because of `strdup()`. The fix involves using std::filesystem. We create a std::filesystem::path object and then return the steam of that path.