### PR TITLE
Fix memory reported unreadable during TTD when readable region is smaller than a cache block

### DIFF
--- a/core/adapters/dbgengadapter.cpp
+++ b/core/adapters/dbgengadapter.cpp
@@ -2301,12 +2301,14 @@ DataBuffer DbgEngAdapter::ReadMemory(std::uintptr_t address, std::size_t size)
 	const auto source = std::make_unique<std::uint8_t[]>(size);
 
 	unsigned long bytesRead {};
-	const auto success =
-		this->m_debugDataSpaces->ReadVirtual(address, source.get(), (ULONG)size, &bytesRead) == S_OK && bytesRead == size;
-	if (!success)
+	const auto result = this->m_debugDataSpaces->ReadVirtual(address, source.get(), (ULONG)size, &bytesRead);
+	// The number of bytes actually read can be fewer than requested, e.g., when the requested region straddles the end
+	// of a readable range (common during TTD). As long as we read at least one byte, return what we got, and let the
+	// caller (the memory cache) treat the partial read as a success. See Vector35/debugger#725.
+	if (result != S_OK || bytesRead == 0)
 		return {};
 
-	return {source.get(), size};
+	return {source.get(), bytesRead};
 }
 
 bool DbgEngAdapter::WriteMemory(std::uintptr_t address, const DataBuffer& buffer)

--- a/core/debuggerstate.cpp
+++ b/core/debuggerstate.cpp
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#include <algorithm>
 #include <chrono>
 #include <thread>
 #include <utility>
@@ -1312,80 +1313,96 @@ void DebuggerMemory::MarkDirty()
 }
 
 
-DataBuffer DebuggerMemory::ReadBlock(uint64_t block)
+DataBuffer DebuggerMemory::ReadRun(uint64_t address)
 {
 	if (!m_state->IsConnected())
 		return {};
 
-	auto iter = m_valueCache.find(block);
-	if (iter != m_valueCache.end())
+	// Look up the cached run (readable bytes or a hole marker) that covers `address`. Entries are keyed by their
+	// start address and cover [key, key + length), so the covering entry is the greatest key <= address.
+	auto covering = m_valueCache.upper_bound(address);
+	if (covering != m_valueCache.begin())
 	{
-		switch (iter->second.status)
+		--covering;
+		auto& entry = covering->second;
+		if (address < covering->first + entry.length)
 		{
-		case FailedToReadStatus:
-			return {};
-		case OutOfDateStatus:
-		{
-			if (m_state->IsRunning())
+			uint64_t inner = address - covering->first;
+			switch (entry.status)
 			{
-				// The cache is old but the target is running, return old value
-				return iter->second.value;
+			case FailedToReadStatus:
+				// A known-unreadable byte; the caller's readable prefix ends here.
+				return {};
+			case OutOfDateStatus:
+				if (m_state->IsRunning())
+				{
+					// The cache is old but the target is running, return the old value
+					if (entry.value.GetLength() > inner)
+						return entry.value.GetSlice(inner, entry.value.GetLength() - inner);
+					return {};
+				}
+				// The target is stopped; break out and try to read the new value
+				break;
+			case UpToDateStatus:
+				// Cache is up-to-date, return the value from the requested address onward
+				if (entry.value.GetLength() > inner)
+					return entry.value.GetSlice(inner, entry.value.GetLength() - inner);
+				return {};
+			case DefaultStatus:
+				// There is no useful information about the status, break out and try to read it
+				break;
 			}
-			// Break out and try to read the new value
-			break;
-		}
-		case UpToDateStatus:
-		{
-			// Cache is up-to-date, return the value
-			return iter->second.value;
-		}
-		case DefaultStatus:
-			// There is no useful information about the status, break out and try to read it
-			break;
 		}
 	}
 
 	// Try to read the memory value from the backend
 	if (!m_state->IsRunning())
 	{
-		// The cache is old and the target is stopped, try to update the cache value
+		// The cache is old and the target is stopped, try to update the cache value. We read up to 0x100 bytes
+		// starting *exactly* at `address` and do NOT round it down to a block boundary, so an unreadable region
+		// before `address` is never touched. The backend may return fewer bytes than requested when the readable
+		// region ends before 0x100 bytes; that is a success, not a failure. See Vector35/debugger#725.
 		DataBuffer buffer;
 		{
 			std::lock_guard adapterLock(m_state->AdapterAccessMutex());
-			buffer = m_state->GetAdapter()->ReadMemory(block, 0x100);
+			buffer = m_state->GetAdapter()->ReadMemory(address, 0x100);
 		}
 		BN_RELEASE_ASSERT(buffer.GetLength() <= 0x100);
 		if (buffer.GetLength() > 0)
 		{
-			// Successfully updated
-			m_valueCache[block] = {buffer, UpToDateStatus, PausedTargetSource};
+			// Successfully read one or more bytes starting at `address`
+			m_valueCache[address] = {buffer, buffer.GetLength(), UpToDateStatus, PausedTargetSource};
 			return buffer;
 		}
+
+		// `address` itself is unreadable. Record the failure for this single byte only, so that a readable region
+		// immediately following the hole is not shadowed by an over-broad failure marker.
+		m_valueCache[address] = {{}, 1, FailedToReadStatus, NoSource};
+		return {};
 	}
-	else
+
+	// If the target is running, we try to read the bytes from the original binary view
+	auto iter = m_valueCachePrefilled.upper_bound(address);
+	if (iter != m_valueCachePrefilled.begin())
 	{
-		// If the target is running, we try to read the bytes from the original binary view
-		auto iter = m_valueCachePrefilled.upper_bound(block);
-		if (iter != m_valueCachePrefilled.begin())
+		--iter;
+		if ((address >= iter->first) && (address < iter->second.first))
 		{
-			--iter;
-			if ((block >= iter->first) && (block < iter->second.first))
+			auto offset = address - iter->first;
+			auto avail = iter->second.first - address;
+			auto buffer = iter->second.second.GetSlice(offset, std::min<uint64_t>(0x100, avail));
+			// When the bytes are readable, we return it, but also mark it as out-of-date so that they can be
+			// replaced as soon as the target stops
+			if (buffer.GetLength() > 0)
 			{
-				auto offset = block - iter->first;
-				auto buffer = iter->second.second.GetSlice(offset, 0x100);
-				// When the bytes are readable, we return it, but also mark it as out-of-date so that they can be
-				// replaced as soon as the target stops
-				if (buffer.GetLength() > 0)
-				{
-					m_valueCache[block] = {buffer, OutOfDateStatus, BackingBinaryViewSource};
-					return buffer;
-				}
+				m_valueCache[address] = {buffer, buffer.GetLength(), OutOfDateStatus, BackingBinaryViewSource};
+				return buffer;
 			}
 		}
 	}
 
-	// Update failed
-	m_valueCache[block] = {{}, FailedToReadStatus, NoSource};
+	// Could not satisfy the read while the target is running; do not cache a failure, since the byte may become
+	// readable once the target stops.
 	return {};
 }
 
@@ -1396,32 +1413,30 @@ DataBuffer DebuggerMemory::ReadMemory(uint64_t offset, size_t len)
 
 	DataBuffer result;
 
-	// ProcessView implements read caching in a manner inspired by CPU cache:
-	// Reads are aligned on 256-byte boundaries and 256 bytes long
-
-	// Cache read start: round down addr to nearest 256 byte boundary
-	size_t cacheStart = offset & (~0xffLL);
-	// Cache read end: round up addr+length to nearest 256 byte boundary
-	size_t cacheEnd = (offset + len + 0xFF) & (~0xffLL);
-	// List of 256-byte block addresses to read into the cache to fully cover this region
-	for (uint64_t block = cacheStart; block < cacheEnd; block += 0x100)
+	// ProcessView implements read caching in a manner inspired by CPU cache: reads are cached in runs of up to
+	// 256 bytes. Unlike a CPU cache we do NOT align reads down to a 256-byte boundary, because the bytes before
+	// `offset` may be unreadable even when `offset` itself is readable (common during TTD, where readability is
+	// tracked at byte granularity rather than page granularity). We therefore anchor each backend read at the
+	// exact address we need and return the contiguous readable prefix starting at `offset`.
+	uint64_t pos = offset;
+	uint64_t end = offset + len;
+	while (pos < end)
 	{
-		auto cached = ReadBlock(block);
-		if (cached.GetLength() == 0)
-			return result;
+		DataBuffer run = ReadRun(pos);
+		if (run.GetLength() == 0)
+			// `pos` is unreadable, so the contiguous readable region ends here
+			break;
 
-		if (offset + len < block + cached.GetLength())
-		{
-			// Last block
-			cached = cached.GetSlice(0, offset + len - block);
-		}
-		// Note a block can be both the fist and the last block, so we should not put an else here
-		if (offset > block)
-		{
-			// First block
-			cached = cached.GetSlice(offset - block, cached.GetLength() - (offset - block));
-		}
-		result.Append(cached);
+		uint64_t take = std::min<uint64_t>(run.GetLength(), end - pos);
+		result.Append(run.GetSlice(0, take));
+		pos += take;
+
+		if (take < run.GetLength())
+			// The run more than covered the rest of the request; we are done
+			break;
+
+		// Otherwise the run may have been cut short by a hole at `pos`; the next ReadRun(pos) will report it and
+		// terminate the loop (also caching the hole marker for that byte).
 	}
 	BN_RELEASE_ASSERT(result.GetLength() <= len);
 	return result;

--- a/core/debuggerstate.cpp
+++ b/core/debuggerstate.cpp
@@ -1313,7 +1313,7 @@ void DebuggerMemory::MarkDirty()
 }
 
 
-DataBuffer DebuggerMemory::ReadRun(uint64_t address)
+DataBuffer DebuggerMemory::ReadAndCacheBlock(uint64_t address)
 {
 	if (!m_state->IsConnected())
 		return {};
@@ -1358,16 +1358,16 @@ DataBuffer DebuggerMemory::ReadRun(uint64_t address)
 	// Try to read the memory value from the backend
 	if (!m_state->IsRunning())
 	{
-		// The cache is old and the target is stopped, try to update the cache value. We read up to 0x100 bytes
-		// starting *exactly* at `address` and do NOT round it down to a block boundary, so an unreadable region
+		// The cache is old and the target is stopped, try to update the cache value. We read up to CacheBlockSize
+		// bytes starting *exactly* at `address` and do NOT round it down to a block boundary, so an unreadable region
 		// before `address` is never touched. The backend may return fewer bytes than requested when the readable
-		// region ends before 0x100 bytes; that is a success, not a failure. See Vector35/debugger#725.
+		// region ends before CacheBlockSize bytes; that is a success, not a failure. See Vector35/debugger#725.
 		DataBuffer buffer;
 		{
 			std::lock_guard adapterLock(m_state->AdapterAccessMutex());
-			buffer = m_state->GetAdapter()->ReadMemory(address, 0x100);
+			buffer = m_state->GetAdapter()->ReadMemory(address, CacheBlockSize);
 		}
-		BN_RELEASE_ASSERT(buffer.GetLength() <= 0x100);
+		BN_RELEASE_ASSERT(buffer.GetLength() <= CacheBlockSize);
 		if (buffer.GetLength() > 0)
 		{
 			// Successfully read one or more bytes starting at `address`
@@ -1390,7 +1390,7 @@ DataBuffer DebuggerMemory::ReadRun(uint64_t address)
 		{
 			auto offset = address - iter->first;
 			auto avail = iter->second.first - address;
-			auto buffer = iter->second.second.GetSlice(offset, std::min<uint64_t>(0x100, avail));
+			auto buffer = iter->second.second.GetSlice(offset, std::min<uint64_t>(CacheBlockSize, avail));
 			// When the bytes are readable, we return it, but also mark it as out-of-date so that they can be
 			// replaced as soon as the target stops
 			if (buffer.GetLength() > 0)
@@ -1422,7 +1422,7 @@ DataBuffer DebuggerMemory::ReadMemory(uint64_t offset, size_t len)
 	uint64_t end = offset + len;
 	while (pos < end)
 	{
-		DataBuffer run = ReadRun(pos);
+		DataBuffer run = ReadAndCacheBlock(pos);
 		if (run.GetLength() == 0)
 			// `pos` is unreadable, so the contiguous readable region ends here
 			break;
@@ -1435,7 +1435,7 @@ DataBuffer DebuggerMemory::ReadMemory(uint64_t offset, size_t len)
 			// The run more than covered the rest of the request; we are done
 			break;
 
-		// Otherwise the run may have been cut short by a hole at `pos`; the next ReadRun(pos) will report it and
+		// Otherwise the run may have been cut short by a hole at `pos`; the next ReadAndCacheBlock(pos) will report it and
 		// terminate the loop (also caching the hole marker for that byte).
 	}
 	BN_RELEASE_ASSERT(result.GetLength() <= len);

--- a/core/debuggerstate.h
+++ b/core/debuggerstate.h
@@ -209,7 +209,11 @@ namespace BinaryNinjaDebugger {
 
 	struct MemoryBytesCache
 	{
+		// The readable bytes of this cached run. Empty for a known-unreadable (hole) marker.
 		DataBuffer value;
+		// Number of bytes this entry covers, starting at its key address. For a readable run this equals
+		// value.GetLength(); for a hole marker it is the size of the unreadable region (a single byte).
+		uint64_t length;
 		MemoryByteCacheStatus status;
 		MemoryByteCacheSource source;
 	};
@@ -227,7 +231,9 @@ namespace BinaryNinjaDebugger {
 		DebuggerMemory(DebuggerState* state);
 
 		void MarkDirty();
-		DataBuffer ReadBlock(uint64_t block);
+		// Reads the readable run starting exactly at `address` (up to 0x100 bytes), or an empty buffer if
+		// `address` itself is unreadable. The address is NOT rounded down to a cache-block boundary.
+		DataBuffer ReadRun(uint64_t address);
 		DataBuffer ReadMemory(uint64_t offset, size_t len);
 		bool WriteMemory(std::uintptr_t address, const DataBuffer& buffer);
 		void PrefillValueCache();

--- a/core/debuggerstate.h
+++ b/core/debuggerstate.h
@@ -221,6 +221,9 @@ namespace BinaryNinjaDebugger {
 
 	class DebuggerMemory
 	{
+		// The maximum number of bytes read from the backend and cached in a single block.
+		static constexpr uint64_t CacheBlockSize = 0x100;
+
 		DebuggerState* m_state;
 		std::map<uint64_t, MemoryBytesCache> m_valueCache;
 		std::map<uint64_t, std::pair<uint64_t, DataBuffer>> m_valueCachePrefilled;
@@ -231,9 +234,9 @@ namespace BinaryNinjaDebugger {
 		DebuggerMemory(DebuggerState* state);
 
 		void MarkDirty();
-		// Reads the readable run starting exactly at `address` (up to 0x100 bytes), or an empty buffer if
-		// `address` itself is unreadable. The address is NOT rounded down to a cache-block boundary.
-		DataBuffer ReadRun(uint64_t address);
+		// Reads the readable run starting exactly at `address` (up to CacheBlockSize bytes) and caches it, or returns
+		// an empty buffer if `address` itself is unreadable. The address is NOT rounded down to a cache-block boundary.
+		DataBuffer ReadAndCacheBlock(uint64_t address);
 		DataBuffer ReadMemory(uint64_t offset, size_t len);
 		bool WriteMemory(std::uintptr_t address, const DataBuffer& buffer);
 		void PrefillValueCache();


### PR DESCRIPTION
Fixes #725.

During TTD, memory readability is tracked at the granularity of what the recorded execution actually touched, so a readable region can be **smaller than the `0x100` chunk** the debugger reads and can **start at a non-`0x100`-aligned address**. Two bugs caused such memory to be reported as entirely unreadable in the linear view (even though `dx`/windbg could read it):

### 1. Adapter discarded partial reads (`core/adapters/dbgengadapter.cpp`)
`DbgEngAdapter::ReadMemory` required `bytesRead == size`, so a valid partial read (e.g. `0x20` of a requested `0x100` bytes) was thrown away as a total failure. This went unnoticed in live debugging because the OS allocator hands out page-sized regions. It now returns the bytes actually read whenever `ReadVirtual` succeeds and reads ≥ 1 byte — the contract other adapters (e.g. GDB) already honor.

### 2. Cache poisoned by holes before the requested address (`core/debuggerstate.{h,cpp}`)
`DebuggerMemory::ReadMemory` rounded every read **down to a `0x100` block boundary** and read the whole block from its base. When the base fell in an unreadable hole, the entire block was marked `FailedToRead`, shadowing the readable bytes that follow the hole.

The cache now:
- anchors each backend read at the **exact requested address** (no round-down), so an unreadable region *before* the requested address is never touched; and
- records read failures at **single-byte granularity**, so a hole never shadows a readable region immediately after it.

`ReadBlock` is replaced by `ReadRun`; the cache stores variable-length runs (readable bytes or one-byte hole markers) keyed by start address. This fix lives in the **generic cache layer**, so it applies to every adapter, not just DbgEng.

### Reproduction
Reproduced with a TTD trace where a separate process `VirtualAllocEx` + `WriteProcessMemory`s a small, misaligned `0x20`-byte buffer into the traced target (so the target executes no write instruction on that page and TTD never page-snapshots it); the target's byte-granular reads then leave a sub-`0x100`, non-aligned readable window. Confirmed via dbgeng that the window is `0x40` bytes at a non-`0x100`-aligned address, and that `read_memory` returns `b''` on a pre-fix build vs the bytes on the fixed build. (Test source/binaries not included in this PR.)