### PR TITLE
Add TTD go to previous/next register write (#1123)

### DIFF
--- a/api/debuggerapi.h
+++ b/api/debuggerapi.h
@@ -902,8 +902,8 @@ namespace BinaryNinjaDebuggerAPI {
 		bool SetTTDPosition(const TTDPosition& position);
 		std::pair<bool, TTDMemoryEvent> GetTTDNextMemoryAccess(uint64_t address, uint64_t size, TTDMemoryAccessType accessType);
 		std::pair<bool, TTDMemoryEvent> GetTTDPrevMemoryAccess(uint64_t address, uint64_t size, TTDMemoryAccessType accessType);
-		std::pair<bool, TTDRegisterWriteEvent> GetTTDNextRegisterWrite(const std::string& reg);
-		std::pair<bool, TTDRegisterWriteEvent> GetTTDPrevRegisterWrite(const std::string& reg);
+		std::optional<TTDRegisterWriteEvent> GetTTDNextRegisterWrite(const std::string& reg);
+		std::optional<TTDRegisterWriteEvent> GetTTDPrevRegisterWrite(const std::string& reg);
 
 		// TTD Position History Navigation
 		bool TTDNavigateBack();

--- a/api/debuggerapi.h
+++ b/api/debuggerapi.h
@@ -531,6 +531,18 @@ namespace BinaryNinjaDebuggerAPI {
 		TTDMemoryEvent() : threadId(0), uniqueThreadId(0), accessType(TTDMemoryRead), address(0), size(0), memoryAddress(0), instructionAddress(0), value(0) {}
 	};
 
+	struct TTDRegisterWriteEvent
+	{
+		std::string reg;               // Register name that was queried (e.g. "rax")
+		TTDPosition position;          // Position at which the register value changed
+		TTDPosition originalPosition;  // Position from which the query was issued
+		uint64_t value;                // Value the register was changed to
+		uint64_t originalValue;        // Value the register held before the change
+		uint32_t uniqueThreadId;       // Unique thread identifier that performed the write
+
+		TTDRegisterWriteEvent() : value(0), originalValue(0), uniqueThreadId(0) {}
+	};
+
 	struct TTDPositionRangeIndexedMemoryEvent{
 		TTDPosition position;				// Position of the memory event
 		uint32_t threadId;					// Thread ID that performed the access
@@ -890,6 +902,8 @@ namespace BinaryNinjaDebuggerAPI {
 		bool SetTTDPosition(const TTDPosition& position);
 		std::pair<bool, TTDMemoryEvent> GetTTDNextMemoryAccess(uint64_t address, uint64_t size, TTDMemoryAccessType accessType);
 		std::pair<bool, TTDMemoryEvent> GetTTDPrevMemoryAccess(uint64_t address, uint64_t size, TTDMemoryAccessType accessType);
+		std::pair<bool, TTDRegisterWriteEvent> GetTTDNextRegisterWrite(const std::string& reg);
+		std::pair<bool, TTDRegisterWriteEvent> GetTTDPrevRegisterWrite(const std::string& reg);
 
 		// TTD Position History Navigation
 		bool TTDNavigateBack();

--- a/api/debuggercontroller.cpp
+++ b/api/debuggercontroller.cpp
@@ -1464,6 +1464,48 @@ std::pair<bool, TTDMemoryEvent> DebuggerController::GetTTDPrevMemoryAccess(uint6
 	return {true, event};
 }
 
+std::pair<bool, TTDRegisterWriteEvent> DebuggerController::GetTTDNextRegisterWrite(const std::string& reg)
+{
+	BNDebuggerTTDRegisterWriteEvent bnEvent = {};
+
+	bool success = BNDebuggerGetTTDNextRegisterWrite(m_object, reg.c_str(), &bnEvent);
+	if (!success)
+		return {false, TTDRegisterWriteEvent()};
+
+	TTDRegisterWriteEvent event;
+	event.reg = bnEvent.reg ? std::string(bnEvent.reg) : reg;
+	event.position = TTDPosition(bnEvent.position.sequence, bnEvent.position.step);
+	event.originalPosition = TTDPosition(bnEvent.originalPosition.sequence, bnEvent.originalPosition.step);
+	event.value = bnEvent.value;
+	event.originalValue = bnEvent.originalValue;
+	event.uniqueThreadId = bnEvent.uniqueThreadId;
+
+	BNDebuggerFreeTTDRegisterWriteEvent(&bnEvent);
+
+	return {true, event};
+}
+
+std::pair<bool, TTDRegisterWriteEvent> DebuggerController::GetTTDPrevRegisterWrite(const std::string& reg)
+{
+	BNDebuggerTTDRegisterWriteEvent bnEvent = {};
+
+	bool success = BNDebuggerGetTTDPrevRegisterWrite(m_object, reg.c_str(), &bnEvent);
+	if (!success)
+		return {false, TTDRegisterWriteEvent()};
+
+	TTDRegisterWriteEvent event;
+	event.reg = bnEvent.reg ? std::string(bnEvent.reg) : reg;
+	event.position = TTDPosition(bnEvent.position.sequence, bnEvent.position.step);
+	event.originalPosition = TTDPosition(bnEvent.originalPosition.sequence, bnEvent.originalPosition.step);
+	event.value = bnEvent.value;
+	event.originalValue = bnEvent.originalValue;
+	event.uniqueThreadId = bnEvent.uniqueThreadId;
+
+	BNDebuggerFreeTTDRegisterWriteEvent(&bnEvent);
+
+	return {true, event};
+}
+
 std::vector<TTDCallEvent> DebuggerController::GetTTDCallsForSymbols(const std::string& symbols, uint64_t startReturnAddress, uint64_t endReturnAddress)
 {
 	std::vector<TTDCallEvent> result;

--- a/api/debuggercontroller.cpp
+++ b/api/debuggercontroller.cpp
@@ -1464,13 +1464,13 @@ std::pair<bool, TTDMemoryEvent> DebuggerController::GetTTDPrevMemoryAccess(uint6
 	return {true, event};
 }
 
-std::pair<bool, TTDRegisterWriteEvent> DebuggerController::GetTTDNextRegisterWrite(const std::string& reg)
+std::optional<TTDRegisterWriteEvent> DebuggerController::GetTTDNextRegisterWrite(const std::string& reg)
 {
 	BNDebuggerTTDRegisterWriteEvent bnEvent = {};
 
 	bool success = BNDebuggerGetTTDNextRegisterWrite(m_object, reg.c_str(), &bnEvent);
 	if (!success)
-		return {false, TTDRegisterWriteEvent()};
+		return std::nullopt;
 
 	TTDRegisterWriteEvent event;
 	event.reg = bnEvent.reg ? std::string(bnEvent.reg) : reg;
@@ -1482,16 +1482,16 @@ std::pair<bool, TTDRegisterWriteEvent> DebuggerController::GetTTDNextRegisterWri
 
 	BNDebuggerFreeTTDRegisterWriteEvent(&bnEvent);
 
-	return {true, event};
+	return event;
 }
 
-std::pair<bool, TTDRegisterWriteEvent> DebuggerController::GetTTDPrevRegisterWrite(const std::string& reg)
+std::optional<TTDRegisterWriteEvent> DebuggerController::GetTTDPrevRegisterWrite(const std::string& reg)
 {
 	BNDebuggerTTDRegisterWriteEvent bnEvent = {};
 
 	bool success = BNDebuggerGetTTDPrevRegisterWrite(m_object, reg.c_str(), &bnEvent);
 	if (!success)
-		return {false, TTDRegisterWriteEvent()};
+		return std::nullopt;
 
 	TTDRegisterWriteEvent event;
 	event.reg = bnEvent.reg ? std::string(bnEvent.reg) : reg;
@@ -1503,7 +1503,7 @@ std::pair<bool, TTDRegisterWriteEvent> DebuggerController::GetTTDPrevRegisterWri
 
 	BNDebuggerFreeTTDRegisterWriteEvent(&bnEvent);
 
-	return {true, event};
+	return event;
 }
 
 std::vector<TTDCallEvent> DebuggerController::GetTTDCallsForSymbols(const std::string& symbols, uint64_t startReturnAddress, uint64_t endReturnAddress)

--- a/api/ffi.h
+++ b/api/ffi.h
@@ -349,6 +349,16 @@ extern "C"
 		BNDebuggerTTDMemoryAccessType accessType;
 	} BNDebuggerTTDMemoryEvent;
 
+	typedef struct BNDebuggerTTDRegisterWriteEvent
+	{
+		char* reg;                          // Register name that was queried/written
+		BNDebuggerTTDPosition position;         // Position at which the register value changed
+		BNDebuggerTTDPosition originalPosition; // Position from which the query was issued
+		uint64_t value;                     // Value the register was changed to
+		uint64_t originalValue;             // Value the register held before the change
+		uint32_t uniqueThreadId;            // Unique thread identifier that performed the write
+	} BNDebuggerTTDRegisterWriteEvent;
+
 	typedef struct BNDebuggerTTDPositionRangeIndexedMemoryEvent
 	{
 		BNDebuggerTTDPosition position;
@@ -763,6 +773,11 @@ extern "C"
 		uint64_t address, uint64_t size, BNDebuggerTTDMemoryAccessType accessType, BNDebuggerTTDMemoryEvent* result);
 	DEBUGGER_FFI_API bool BNDebuggerGetTTDPrevMemoryAccess(BNDebuggerController* controller,
 		uint64_t address, uint64_t size, BNDebuggerTTDMemoryAccessType accessType, BNDebuggerTTDMemoryEvent* result);
+	DEBUGGER_FFI_API bool BNDebuggerGetTTDNextRegisterWrite(BNDebuggerController* controller,
+		const char* reg, BNDebuggerTTDRegisterWriteEvent* result);
+	DEBUGGER_FFI_API bool BNDebuggerGetTTDPrevRegisterWrite(BNDebuggerController* controller,
+		const char* reg, BNDebuggerTTDRegisterWriteEvent* result);
+	DEBUGGER_FFI_API void BNDebuggerFreeTTDRegisterWriteEvent(BNDebuggerTTDRegisterWriteEvent* event);
 	DEBUGGER_FFI_API void BNDebuggerFreeTTDMemoryEvents(BNDebuggerTTDMemoryEvent* events, size_t count);
 	DEBUGGER_FFI_API void BNDebuggerFreeTTDPositionRangeIndexedMemoryEvents(BNDebuggerTTDPositionRangeIndexedMemoryEvent* events, size_t count);
 	DEBUGGER_FFI_API void BNDebuggerFreeTTDCallEvents(BNDebuggerTTDCallEvent* events, size_t count);

--- a/api/python/debuggercontroller.py
+++ b/api/python/debuggercontroller.py
@@ -892,6 +892,60 @@ class TTDMemoryEvent:
         return f"<TTDMemoryEvent: {self.event_type} @ {self.address:#x}, thread {self.thread_id}>"
 
 
+class TTDRegisterWriteEvent:
+    """
+    TTDRegisterWriteEvent represents the result of a TTD PrevRegisterWrite/NextRegisterWrite
+    query, i.e. the point at which a register's value last changed. It has the following fields:
+
+    * ``reg``: name of the register that was queried (e.g. "rax")
+    * ``position``: TTD position at which the register value changed
+    * ``original_position``: TTD position from which the query was issued
+    * ``value``: value the register was changed to
+    * ``original_value``: value the register held before the change
+    * ``unique_thread_id``: unique thread ID that performed the write
+
+    .. note:: These queries detect when a register *changes* value, not every architectural \
+    write. Writing the same value a register already holds is not reported.
+    """
+
+    def __init__(self, reg: str, position: TTDPosition, original_position: TTDPosition,
+                 value: int, original_value: int, unique_thread_id: int):
+        self.reg = reg
+        self.position = position
+        self.original_position = original_position
+        self.value = value
+        self.original_value = original_value
+        self.unique_thread_id = unique_thread_id
+
+    def __eq__(self, other):
+        if not isinstance(other, self.__class__):
+            return NotImplemented
+        return (self.reg == other.reg and
+                self.position == other.position and
+                self.original_position == other.original_position and
+                self.value == other.value and
+                self.original_value == other.original_value and
+                self.unique_thread_id == other.unique_thread_id)
+
+    def __ne__(self, other):
+        if not isinstance(other, self.__class__):
+            return NotImplemented
+        return not (self == other)
+
+    def __hash__(self):
+        return hash((self.reg, self.position, self.original_position,
+                     self.value, self.original_value, self.unique_thread_id))
+
+    def __setattr__(self, name, value):
+        try:
+            object.__setattr__(self, name, value)
+        except AttributeError:
+            raise AttributeError(f"attribute '{name}' is read only")
+
+    def __repr__(self):
+        return f"<TTDRegisterWriteEvent: {self.reg}={self.value:#x} @ {self.position}>"
+
+
 class TTDPositionRangeIndexedMemoryEvent:
     """
     TTDPositionRangeIndexedMemoryEvent represents a memory access event in a TTD trace with position information.
@@ -3029,6 +3083,66 @@ class DebuggerController:
             value=result.value,
             access_type=result.accessType
         )
+
+    def get_ttd_next_register_write(self, reg: str) -> Optional[TTDRegisterWriteEvent]:
+        """
+        Find the next position at which the given register's value changes, starting from the
+        current TTD position, and return information about that write.
+
+        This uses the TTD ``NextRegisterWrite`` API directly, so it does not move the current
+        position. Use ``set_ttd_position`` with the returned ``position`` to travel there.
+
+        .. note:: This detects when a register *changes* value, not every architectural write. \
+        Writing the same value a register already holds is not reported.
+
+        :param reg: name of the register to query (e.g. "rax")
+        :return: TTDRegisterWriteEvent if found, None if no subsequent write exists
+        """
+        result = dbgcore.BNDebuggerTTDRegisterWriteEvent()
+        success = dbgcore.BNDebuggerGetTTDNextRegisterWrite(self.handle, reg, result)
+        if not success:
+            return None
+
+        event = TTDRegisterWriteEvent(
+            reg=result.reg if result.reg else reg,
+            position=TTDPosition(result.position.sequence, result.position.step),
+            original_position=TTDPosition(result.originalPosition.sequence, result.originalPosition.step),
+            value=result.value,
+            original_value=result.originalValue,
+            unique_thread_id=result.uniqueThreadId
+        )
+        dbgcore.BNDebuggerFreeTTDRegisterWriteEvent(result)
+        return event
+
+    def get_ttd_prev_register_write(self, reg: str) -> Optional[TTDRegisterWriteEvent]:
+        """
+        Find the previous position at which the given register's value changed, going backward
+        from the current TTD position, and return information about that write.
+
+        This uses the TTD ``PrevRegisterWrite`` API directly, so it does not move the current
+        position. Use ``set_ttd_position`` with the returned ``position`` to travel there.
+
+        .. note:: This detects when a register *changes* value, not every architectural write. \
+        Writing the same value a register already holds is not reported.
+
+        :param reg: name of the register to query (e.g. "rax")
+        :return: TTDRegisterWriteEvent if found, None if no prior write exists
+        """
+        result = dbgcore.BNDebuggerTTDRegisterWriteEvent()
+        success = dbgcore.BNDebuggerGetTTDPrevRegisterWrite(self.handle, reg, result)
+        if not success:
+            return None
+
+        event = TTDRegisterWriteEvent(
+            reg=result.reg if result.reg else reg,
+            position=TTDPosition(result.position.sequence, result.position.step),
+            original_position=TTDPosition(result.originalPosition.sequence, result.originalPosition.step),
+            value=result.value,
+            original_value=result.originalValue,
+            unique_thread_id=result.uniqueThreadId
+        )
+        dbgcore.BNDebuggerFreeTTDRegisterWriteEvent(result)
+        return event
 
     def get_ttd_memory_access_for_address(self, address: int, end_address: int, access_type = DebuggerTTDMemoryAccessType.DebuggerTTDMemoryRead) -> List[TTDMemoryEvent]:
         """

--- a/core/adapters/dbgengttdadapter.cpp
+++ b/core/adapters/dbgengttdadapter.cpp
@@ -600,18 +600,18 @@ std::pair<bool, TTDMemoryEvent> DbgEngTTDAdapter::GetTTDPrevMemoryAccess(uint64_
 }
 
 
-std::pair<bool, TTDRegisterWriteEvent> DbgEngTTDAdapter::GetTTDNextRegisterWrite(const std::string& reg)
+std::optional<TTDRegisterWriteEvent> DbgEngTTDAdapter::GetTTDNextRegisterWrite(const std::string& reg)
 {
 	if (!m_debugControl)
 	{
 		LogError("Debug control interface not available");
-		return {false, TTDRegisterWriteEvent()};
+		return std::nullopt;
 	}
 
 	if (reg.empty())
 	{
 		LogError("Invalid register name specified");
-		return {false, TTDRegisterWriteEvent()};
+		return std::nullopt;
 	}
 
 	try
@@ -624,23 +624,23 @@ std::pair<bool, TTDRegisterWriteEvent> DbgEngTTDAdapter::GetTTDNextRegisterWrite
 	catch (const std::exception& e)
 	{
 		LogError("Exception in GetTTDNextRegisterWrite: %s", e.what());
-		return {false, TTDRegisterWriteEvent()};
+		return std::nullopt;
 	}
 }
 
 
-std::pair<bool, TTDRegisterWriteEvent> DbgEngTTDAdapter::GetTTDPrevRegisterWrite(const std::string& reg)
+std::optional<TTDRegisterWriteEvent> DbgEngTTDAdapter::GetTTDPrevRegisterWrite(const std::string& reg)
 {
 	if (!m_debugControl)
 	{
 		LogError("Debug control interface not available");
-		return {false, TTDRegisterWriteEvent()};
+		return std::nullopt;
 	}
 
 	if (reg.empty())
 	{
 		LogError("Invalid register name specified");
-		return {false, TTDRegisterWriteEvent()};
+		return std::nullopt;
 	}
 
 	try
@@ -653,7 +653,7 @@ std::pair<bool, TTDRegisterWriteEvent> DbgEngTTDAdapter::GetTTDPrevRegisterWrite
 	catch (const std::exception& e)
 	{
 		LogError("Exception in GetTTDPrevRegisterWrite: %s", e.what());
-		return {false, TTDRegisterWriteEvent()};
+		return std::nullopt;
 	}
 }
 
@@ -1539,7 +1539,7 @@ std::pair<bool, TTDMemoryEvent> DbgEngTTDAdapter::ParseSingleTTDMemoryObject(con
 }
 
 
-std::pair<bool, TTDRegisterWriteEvent> DbgEngTTDAdapter::ParseSingleTTDRegisterWriteObject(const std::string& expression, const std::string& reg)
+std::optional<TTDRegisterWriteEvent> DbgEngTTDAdapter::ParseSingleTTDRegisterWriteObject(const std::string& expression, const std::string& reg)
 {
 	TTDRegisterWriteEvent event;
 	event.reg = reg;
@@ -1547,7 +1547,7 @@ std::pair<bool, TTDRegisterWriteEvent> DbgEngTTDAdapter::ParseSingleTTDRegisterW
 	if (!m_hostEvaluator)
 	{
 		LogError("Data model evaluator not available");
-		return {false, event};
+		return std::nullopt;
 	}
 
 	try
@@ -1558,7 +1558,7 @@ std::pair<bool, TTDRegisterWriteEvent> DbgEngTTDAdapter::ParseSingleTTDRegisterW
 		if (FAILED(m_debugHost->GetCurrentContext(hostContext.GetAddressOf())))
 		{
 			LogError("Failed to get current debug host context");
-			return {false, event};
+			return std::nullopt;
 		}
 
 		ComPtr<IModelObject> result;
@@ -1576,13 +1576,13 @@ std::pair<bool, TTDRegisterWriteEvent> DbgEngTTDAdapter::ParseSingleTTDRegisterW
 			// A failed evaluation typically means there is no previous/next write of this
 			// register within the trace, which is a normal "not found" outcome.
 			LogInfo("No register write found for expression '%s' (0x%08x)", expression.c_str(), hr);
-			return {false, event};
+			return std::nullopt;
 		}
 
 		if (!result)
 		{
 			LogInfo("No register write found for expression '%s'", expression.c_str());
-			return {false, event};
+			return std::nullopt;
 		}
 
 		// Parse Position (where the register value changed)
@@ -1654,12 +1654,12 @@ std::pair<bool, TTDRegisterWriteEvent> DbgEngTTDAdapter::ParseSingleTTDRegisterW
 
 		LogInfo("Successfully parsed TTD register write for '%s' at position %llx:%llx",
 			event.reg.c_str(), event.position.sequence, event.position.step);
-		return {true, event};
+		return event;
 	}
 	catch (const std::exception& e)
 	{
 		LogError("Exception in ParseSingleTTDRegisterWriteObject: %s", e.what());
-		return {false, event};
+		return std::nullopt;
 	}
 }
 

--- a/core/adapters/dbgengttdadapter.cpp
+++ b/core/adapters/dbgengttdadapter.cpp
@@ -600,6 +600,64 @@ std::pair<bool, TTDMemoryEvent> DbgEngTTDAdapter::GetTTDPrevMemoryAccess(uint64_
 }
 
 
+std::pair<bool, TTDRegisterWriteEvent> DbgEngTTDAdapter::GetTTDNextRegisterWrite(const std::string& reg)
+{
+	if (!m_debugControl)
+	{
+		LogError("Debug control interface not available");
+		return {false, TTDRegisterWriteEvent()};
+	}
+
+	if (reg.empty())
+	{
+		LogError("Invalid register name specified");
+		return {false, TTDRegisterWriteEvent()};
+	}
+
+	try
+	{
+		std::string expression = fmt::format("@$curthread.TTD.NextRegisterWrite(\"{}\")", reg);
+		LogInfo("Executing TTD NextRegisterWrite query: %s", expression.c_str());
+
+		return ParseSingleTTDRegisterWriteObject(expression, reg);
+	}
+	catch (const std::exception& e)
+	{
+		LogError("Exception in GetTTDNextRegisterWrite: %s", e.what());
+		return {false, TTDRegisterWriteEvent()};
+	}
+}
+
+
+std::pair<bool, TTDRegisterWriteEvent> DbgEngTTDAdapter::GetTTDPrevRegisterWrite(const std::string& reg)
+{
+	if (!m_debugControl)
+	{
+		LogError("Debug control interface not available");
+		return {false, TTDRegisterWriteEvent()};
+	}
+
+	if (reg.empty())
+	{
+		LogError("Invalid register name specified");
+		return {false, TTDRegisterWriteEvent()};
+	}
+
+	try
+	{
+		std::string expression = fmt::format("@$curthread.TTD.PrevRegisterWrite(\"{}\")", reg);
+		LogInfo("Executing TTD PrevRegisterWrite query: %s", expression.c_str());
+
+		return ParseSingleTTDRegisterWriteObject(expression, reg);
+	}
+	catch (const std::exception& e)
+	{
+		LogError("Exception in GetTTDPrevRegisterWrite: %s", e.what());
+		return {false, TTDRegisterWriteEvent()};
+	}
+}
+
+
 bool DbgEngTTDAdapter::QueryMemoryAccessByAddress(uint64_t startAddress, uint64_t endAddress, TTDMemoryAccessType accessType, std::vector<TTDMemoryEvent>& events)
 {
 	if (!m_debugControl)
@@ -1476,6 +1534,131 @@ std::pair<bool, TTDMemoryEvent> DbgEngTTDAdapter::ParseSingleTTDMemoryObject(con
 	catch (const std::exception& e)
 	{
 		LogError("Exception in ParseSingleTTDMemoryObject: %s", e.what());
+		return {false, event};
+	}
+}
+
+
+std::pair<bool, TTDRegisterWriteEvent> DbgEngTTDAdapter::ParseSingleTTDRegisterWriteObject(const std::string& expression, const std::string& reg)
+{
+	TTDRegisterWriteEvent event;
+	event.reg = reg;
+
+	if (!m_hostEvaluator)
+	{
+		LogError("Data model evaluator not available");
+		return {false, event};
+	}
+
+	try
+	{
+		std::wstring wExpression(expression.begin(), expression.end());
+
+		ComPtr<IDebugHostContext> hostContext;
+		if (FAILED(m_debugHost->GetCurrentContext(hostContext.GetAddressOf())))
+		{
+			LogError("Failed to get current debug host context");
+			return {false, event};
+		}
+
+		ComPtr<IModelObject> result;
+		ComPtr<IKeyStore> metadata;
+		HRESULT hr = m_hostEvaluator->EvaluateExtendedExpression(
+			hostContext.Get(),
+			wExpression.c_str(),
+			nullptr,
+			result.GetAddressOf(),
+			metadata.GetAddressOf()
+		);
+
+		if (FAILED(hr))
+		{
+			// A failed evaluation typically means there is no previous/next write of this
+			// register within the trace, which is a normal "not found" outcome.
+			LogInfo("No register write found for expression '%s' (0x%08x)", expression.c_str(), hr);
+			return {false, event};
+		}
+
+		if (!result)
+		{
+			LogInfo("No register write found for expression '%s'", expression.c_str());
+			return {false, event};
+		}
+
+		// Parse Position (where the register value changed)
+		ComPtr<IModelObject> positionObj;
+		if (SUCCEEDED(result->GetKeyValue(L"Position", &positionObj, nullptr)))
+		{
+			ParseTTDPosition(positionObj.Get(), event.position);
+		}
+
+		// Parse OriginalPosition (the position from which the query was made)
+		ComPtr<IModelObject> origPositionObj;
+		if (SUCCEEDED(result->GetKeyValue(L"OriginalPosition", &origPositionObj, nullptr)))
+		{
+			ParseTTDPosition(origPositionObj.Get(), event.originalPosition);
+		}
+
+		// Get Register name (fall back to the queried name if unavailable)
+		ComPtr<IModelObject> regObj;
+		if (SUCCEEDED(result->GetKeyValue(L"Register", &regObj, nullptr)))
+		{
+			VARIANT vtReg;
+			VariantInit(&vtReg);
+			if (SUCCEEDED(regObj->GetIntrinsicValueAs(VT_BSTR, &vtReg)) && vtReg.bstrVal)
+			{
+				_bstr_t bstr(vtReg.bstrVal);
+				event.reg = std::string(bstr);
+			}
+			VariantClear(&vtReg);
+		}
+
+		// Get Value (value the register was changed to)
+		ComPtr<IModelObject> valueObj;
+		if (SUCCEEDED(result->GetKeyValue(L"Value", &valueObj, nullptr)))
+		{
+			VARIANT vtValue;
+			VariantInit(&vtValue);
+			if (SUCCEEDED(valueObj->GetIntrinsicValueAs(VT_UI8, &vtValue)))
+			{
+				event.value = vtValue.ullVal;
+			}
+			VariantClear(&vtValue);
+		}
+
+		// Get OriginalValue (value the register held before the change)
+		ComPtr<IModelObject> origValueObj;
+		if (SUCCEEDED(result->GetKeyValue(L"OriginalValue", &origValueObj, nullptr)))
+		{
+			VARIANT vtOrigValue;
+			VariantInit(&vtOrigValue);
+			if (SUCCEEDED(origValueObj->GetIntrinsicValueAs(VT_UI8, &vtOrigValue)))
+			{
+				event.originalValue = vtOrigValue.ullVal;
+			}
+			VariantClear(&vtOrigValue);
+		}
+
+		// Get UniqueThreadId
+		ComPtr<IModelObject> uniqueThreadIdObj;
+		if (SUCCEEDED(result->GetKeyValue(L"UniqueThreadId", &uniqueThreadIdObj, nullptr)))
+		{
+			VARIANT vtUniqueThreadId;
+			VariantInit(&vtUniqueThreadId);
+			if (SUCCEEDED(uniqueThreadIdObj->GetIntrinsicValueAs(VT_UI4, &vtUniqueThreadId)))
+			{
+				event.uniqueThreadId = vtUniqueThreadId.ulVal;
+			}
+			VariantClear(&vtUniqueThreadId);
+		}
+
+		LogInfo("Successfully parsed TTD register write for '%s' at position %llx:%llx",
+			event.reg.c_str(), event.position.sequence, event.position.step);
+		return {true, event};
+	}
+	catch (const std::exception& e)
+	{
+		LogError("Exception in ParseSingleTTDRegisterWriteObject: %s", e.what());
 		return {false, event};
 	}
 }

--- a/core/adapters/dbgengttdadapter.h
+++ b/core/adapters/dbgengttdadapter.h
@@ -58,6 +58,10 @@ namespace BinaryNinjaDebugger {
 		std::pair<bool, TTDMemoryEvent> GetTTDNextMemoryAccess(uint64_t address, uint64_t size, TTDMemoryAccessType accessType) override;
 		std::pair<bool, TTDMemoryEvent> GetTTDPrevMemoryAccess(uint64_t address, uint64_t size, TTDMemoryAccessType accessType) override;
 
+		// TTD Next/Prev Register Write Methods
+		std::pair<bool, TTDRegisterWriteEvent> GetTTDNextRegisterWrite(const std::string& reg) override;
+		std::pair<bool, TTDRegisterWriteEvent> GetTTDPrevRegisterWrite(const std::string& reg) override;
+
     	// TTD Calls Analysis Methods
     	std::vector<TTDCallEvent> GetTTDCallsForSymbols(const std::string& symbols, uint64_t startReturnAddress = 0, uint64_t endReturnAddress = 0) override;
 
@@ -97,6 +101,7 @@ namespace BinaryNinjaDebugger {
 		bool ParseTTDMemoryObjects(const std::string& expression, TTDMemoryAccessType accessType, std::vector<TTDMemoryEvent>& events);
 		bool ParseTTDPositionRangeIndexedMemoryObjects(const std::string& expression, TTDMemoryAccessType accessType, std::vector<TTDPositionRangeIndexedMemoryEvent>& events);
 		std::pair<bool, TTDMemoryEvent> ParseSingleTTDMemoryObject(const std::string& expression, TTDMemoryAccessType accessType);
+		std::pair<bool, TTDRegisterWriteEvent> ParseSingleTTDRegisterWriteObject(const std::string& expression, const std::string& reg);
 
 		// Data model interfaces for TTD
 		IHostDataModelAccess* m_dataModelManager;

--- a/core/adapters/dbgengttdadapter.h
+++ b/core/adapters/dbgengttdadapter.h
@@ -59,8 +59,8 @@ namespace BinaryNinjaDebugger {
 		std::pair<bool, TTDMemoryEvent> GetTTDPrevMemoryAccess(uint64_t address, uint64_t size, TTDMemoryAccessType accessType) override;
 
 		// TTD Next/Prev Register Write Methods
-		std::pair<bool, TTDRegisterWriteEvent> GetTTDNextRegisterWrite(const std::string& reg) override;
-		std::pair<bool, TTDRegisterWriteEvent> GetTTDPrevRegisterWrite(const std::string& reg) override;
+		std::optional<TTDRegisterWriteEvent> GetTTDNextRegisterWrite(const std::string& reg) override;
+		std::optional<TTDRegisterWriteEvent> GetTTDPrevRegisterWrite(const std::string& reg) override;
 
     	// TTD Calls Analysis Methods
     	std::vector<TTDCallEvent> GetTTDCallsForSymbols(const std::string& symbols, uint64_t startReturnAddress = 0, uint64_t endReturnAddress = 0) override;
@@ -101,7 +101,7 @@ namespace BinaryNinjaDebugger {
 		bool ParseTTDMemoryObjects(const std::string& expression, TTDMemoryAccessType accessType, std::vector<TTDMemoryEvent>& events);
 		bool ParseTTDPositionRangeIndexedMemoryObjects(const std::string& expression, TTDMemoryAccessType accessType, std::vector<TTDPositionRangeIndexedMemoryEvent>& events);
 		std::pair<bool, TTDMemoryEvent> ParseSingleTTDMemoryObject(const std::string& expression, TTDMemoryAccessType accessType);
-		std::pair<bool, TTDRegisterWriteEvent> ParseSingleTTDRegisterWriteObject(const std::string& expression, const std::string& reg);
+		std::optional<TTDRegisterWriteEvent> ParseSingleTTDRegisterWriteObject(const std::string& expression, const std::string& reg);
 
 		// Data model interfaces for TTD
 		IHostDataModelAccess* m_dataModelManager;

--- a/core/debugadapter.cpp
+++ b/core/debugadapter.cpp
@@ -274,3 +274,17 @@ std::pair<bool, TTDMemoryEvent> DebugAdapter::GetTTDPrevMemoryAccess(uint64_t ad
 }
 
 
+std::pair<bool, TTDRegisterWriteEvent> DebugAdapter::GetTTDNextRegisterWrite(const std::string& reg)
+{
+	// Default implementation returns failure for adapters that don't support TTD
+	return {false, TTDRegisterWriteEvent()};
+}
+
+
+std::pair<bool, TTDRegisterWriteEvent> DebugAdapter::GetTTDPrevRegisterWrite(const std::string& reg)
+{
+	// Default implementation returns failure for adapters that don't support TTD
+	return {false, TTDRegisterWriteEvent()};
+}
+
+

--- a/core/debugadapter.cpp
+++ b/core/debugadapter.cpp
@@ -274,17 +274,17 @@ std::pair<bool, TTDMemoryEvent> DebugAdapter::GetTTDPrevMemoryAccess(uint64_t ad
 }
 
 
-std::pair<bool, TTDRegisterWriteEvent> DebugAdapter::GetTTDNextRegisterWrite(const std::string& reg)
+std::optional<TTDRegisterWriteEvent> DebugAdapter::GetTTDNextRegisterWrite(const std::string& reg)
 {
 	// Default implementation returns failure for adapters that don't support TTD
-	return {false, TTDRegisterWriteEvent()};
+	return std::nullopt;
 }
 
 
-std::pair<bool, TTDRegisterWriteEvent> DebugAdapter::GetTTDPrevRegisterWrite(const std::string& reg)
+std::optional<TTDRegisterWriteEvent> DebugAdapter::GetTTDPrevRegisterWrite(const std::string& reg)
 {
 	// Default implementation returns failure for adapters that don't support TTD
-	return {false, TTDRegisterWriteEvent()};
+	return std::nullopt;
 }
 
 

--- a/core/debugadapter.h
+++ b/core/debugadapter.h
@@ -465,8 +465,8 @@ namespace BinaryNinjaDebugger {
 		virtual bool SetTTDPosition(const TTDPosition& position);
 		virtual std::pair<bool, TTDMemoryEvent> GetTTDNextMemoryAccess(uint64_t address, uint64_t size, TTDMemoryAccessType accessType);
 		virtual std::pair<bool, TTDMemoryEvent> GetTTDPrevMemoryAccess(uint64_t address, uint64_t size, TTDMemoryAccessType accessType);
-		virtual std::pair<bool, TTDRegisterWriteEvent> GetTTDNextRegisterWrite(const std::string& reg);
-		virtual std::pair<bool, TTDRegisterWriteEvent> GetTTDPrevRegisterWrite(const std::string& reg);
+		virtual std::optional<TTDRegisterWriteEvent> GetTTDNextRegisterWrite(const std::string& reg);
+		virtual std::optional<TTDRegisterWriteEvent> GetTTDPrevRegisterWrite(const std::string& reg);
 
 	};
 };  // namespace BinaryNinjaDebugger

--- a/core/debugadapter.h
+++ b/core/debugadapter.h
@@ -465,6 +465,8 @@ namespace BinaryNinjaDebugger {
 		virtual bool SetTTDPosition(const TTDPosition& position);
 		virtual std::pair<bool, TTDMemoryEvent> GetTTDNextMemoryAccess(uint64_t address, uint64_t size, TTDMemoryAccessType accessType);
 		virtual std::pair<bool, TTDMemoryEvent> GetTTDPrevMemoryAccess(uint64_t address, uint64_t size, TTDMemoryAccessType accessType);
+		virtual std::pair<bool, TTDRegisterWriteEvent> GetTTDNextRegisterWrite(const std::string& reg);
+		virtual std::pair<bool, TTDRegisterWriteEvent> GetTTDPrevRegisterWrite(const std::string& reg);
 
 	};
 };  // namespace BinaryNinjaDebugger

--- a/core/debuggercommon.h
+++ b/core/debuggercommon.h
@@ -151,6 +151,21 @@ namespace BinaryNinjaDebugger {
 		TTDMemoryEvent() : threadId(0), uniqueThreadId(0), address(0), size(0), memoryAddress(0), instructionAddress(0), value(0), accessType(TTDMemoryRead) {}
 	};
 
+	// TTD Register Write Event - result of TTD.PrevRegisterWrite / TTD.NextRegisterWrite.
+	// These queries locate the position at which a register's value last changed (they detect
+	// value *changes*, not every architectural write - writing the same value is not reported).
+	struct TTDRegisterWriteEvent
+	{
+		std::string reg;               // Register name that was queried (e.g. "rax")
+		TTDPosition position;          // Position at which the register value changed
+		TTDPosition originalPosition;  // Position from which the query was issued
+		uint64_t value;                // Value the register was changed to
+		uint64_t originalValue;        // Value the register held before the change
+		uint32_t uniqueThreadId;       // Unique thread identifier that performed the write
+
+		TTDRegisterWriteEvent() : value(0), originalValue(0), uniqueThreadId(0) {}
+	};
+
 	struct TTDPositionRangeIndexedMemoryEvent{
 		TTDPosition position;				// Position of the memory event
 		uint32_t threadId;					// Thread ID that performed the access

--- a/core/debuggercontroller.cpp
+++ b/core/debuggercontroller.cpp
@@ -3895,12 +3895,12 @@ std::pair<bool, TTDMemoryEvent> DebuggerController::GetTTDPrevMemoryAccess(uint6
 }
 
 
-std::pair<bool, TTDRegisterWriteEvent> DebuggerController::GetTTDNextRegisterWrite(const std::string& reg)
+std::optional<TTDRegisterWriteEvent> DebuggerController::GetTTDNextRegisterWrite(const std::string& reg)
 {
 	if (!m_state->IsConnected() || !IsTTD())
 	{
 		LogWarn("Current adapter does not support TTD");
-		return {false, TTDRegisterWriteEvent()};
+		return std::nullopt;
 	}
 
 	if (m_adapter)
@@ -3908,16 +3908,16 @@ std::pair<bool, TTDRegisterWriteEvent> DebuggerController::GetTTDNextRegisterWri
 		return m_adapter->GetTTDNextRegisterWrite(reg);
 	}
 
-	return {false, TTDRegisterWriteEvent()};
+	return std::nullopt;
 }
 
 
-std::pair<bool, TTDRegisterWriteEvent> DebuggerController::GetTTDPrevRegisterWrite(const std::string& reg)
+std::optional<TTDRegisterWriteEvent> DebuggerController::GetTTDPrevRegisterWrite(const std::string& reg)
 {
 	if (!m_state->IsConnected() || !IsTTD())
 	{
 		LogWarn("Current adapter does not support TTD");
-		return {false, TTDRegisterWriteEvent()};
+		return std::nullopt;
 	}
 
 	if (m_adapter)
@@ -3925,7 +3925,7 @@ std::pair<bool, TTDRegisterWriteEvent> DebuggerController::GetTTDPrevRegisterWri
 		return m_adapter->GetTTDPrevRegisterWrite(reg);
 	}
 
-	return {false, TTDRegisterWriteEvent()};
+	return std::nullopt;
 }
 
 

--- a/core/debuggercontroller.cpp
+++ b/core/debuggercontroller.cpp
@@ -3895,6 +3895,40 @@ std::pair<bool, TTDMemoryEvent> DebuggerController::GetTTDPrevMemoryAccess(uint6
 }
 
 
+std::pair<bool, TTDRegisterWriteEvent> DebuggerController::GetTTDNextRegisterWrite(const std::string& reg)
+{
+	if (!m_state->IsConnected() || !IsTTD())
+	{
+		LogWarn("Current adapter does not support TTD");
+		return {false, TTDRegisterWriteEvent()};
+	}
+
+	if (m_adapter)
+	{
+		return m_adapter->GetTTDNextRegisterWrite(reg);
+	}
+
+	return {false, TTDRegisterWriteEvent()};
+}
+
+
+std::pair<bool, TTDRegisterWriteEvent> DebuggerController::GetTTDPrevRegisterWrite(const std::string& reg)
+{
+	if (!m_state->IsConnected() || !IsTTD())
+	{
+		LogWarn("Current adapter does not support TTD");
+		return {false, TTDRegisterWriteEvent()};
+	}
+
+	if (m_adapter)
+	{
+		return m_adapter->GetTTDPrevRegisterWrite(reg);
+	}
+
+	return {false, TTDRegisterWriteEvent()};
+}
+
+
 static const char* TTD_BOOKMARKS_METADATA_KEY = "debugger.ttd_bookmarks";
 
 std::vector<TTDBookmark> DebuggerController::GetTTDBookmarks()

--- a/core/debuggercontroller.h
+++ b/core/debuggercontroller.h
@@ -639,8 +639,8 @@ namespace BinaryNinjaDebugger {
 		bool SetTTDPosition(const TTDPosition& position);
 		std::pair<bool, TTDMemoryEvent> GetTTDNextMemoryAccess(uint64_t address, uint64_t size, TTDMemoryAccessType accessType);
 		std::pair<bool, TTDMemoryEvent> GetTTDPrevMemoryAccess(uint64_t address, uint64_t size, TTDMemoryAccessType accessType);
-		std::pair<bool, TTDRegisterWriteEvent> GetTTDNextRegisterWrite(const std::string& reg);
-		std::pair<bool, TTDRegisterWriteEvent> GetTTDPrevRegisterWrite(const std::string& reg);
+		std::optional<TTDRegisterWriteEvent> GetTTDNextRegisterWrite(const std::string& reg);
+		std::optional<TTDRegisterWriteEvent> GetTTDPrevRegisterWrite(const std::string& reg);
 
 		// TTD Position History Navigation
 		bool TTDNavigateBack();

--- a/core/debuggercontroller.h
+++ b/core/debuggercontroller.h
@@ -639,6 +639,8 @@ namespace BinaryNinjaDebugger {
 		bool SetTTDPosition(const TTDPosition& position);
 		std::pair<bool, TTDMemoryEvent> GetTTDNextMemoryAccess(uint64_t address, uint64_t size, TTDMemoryAccessType accessType);
 		std::pair<bool, TTDMemoryEvent> GetTTDPrevMemoryAccess(uint64_t address, uint64_t size, TTDMemoryAccessType accessType);
+		std::pair<bool, TTDRegisterWriteEvent> GetTTDNextRegisterWrite(const std::string& reg);
+		std::pair<bool, TTDRegisterWriteEvent> GetTTDPrevRegisterWrite(const std::string& reg);
 
 		// TTD Position History Navigation
 		bool TTDNavigateBack();

--- a/core/ffi.cpp
+++ b/core/ffi.cpp
@@ -1547,6 +1547,55 @@ bool BNDebuggerGetTTDPrevMemoryAccess(BNDebuggerController* controller,
 	return true;
 }
 
+static void FillTTDRegisterWriteEvent(const TTDRegisterWriteEvent& event, BNDebuggerTTDRegisterWriteEvent* result)
+{
+	result->reg = BNDebuggerAllocString(event.reg.c_str());
+	result->position = {event.position.sequence, event.position.step};
+	result->originalPosition = {event.originalPosition.sequence, event.originalPosition.step};
+	result->value = event.value;
+	result->originalValue = event.originalValue;
+	result->uniqueThreadId = event.uniqueThreadId;
+}
+
+bool BNDebuggerGetTTDNextRegisterWrite(BNDebuggerController* controller,
+	const char* reg, BNDebuggerTTDRegisterWriteEvent* result)
+{
+	if (!reg || !result)
+		return false;
+
+	auto [success, event] = controller->object->GetTTDNextRegisterWrite(reg);
+	if (!success)
+		return false;
+
+	FillTTDRegisterWriteEvent(event, result);
+	return true;
+}
+
+bool BNDebuggerGetTTDPrevRegisterWrite(BNDebuggerController* controller,
+	const char* reg, BNDebuggerTTDRegisterWriteEvent* result)
+{
+	if (!reg || !result)
+		return false;
+
+	auto [success, event] = controller->object->GetTTDPrevRegisterWrite(reg);
+	if (!success)
+		return false;
+
+	FillTTDRegisterWriteEvent(event, result);
+	return true;
+}
+
+void BNDebuggerFreeTTDRegisterWriteEvent(BNDebuggerTTDRegisterWriteEvent* event)
+{
+	if (!event)
+		return;
+	if (event->reg)
+	{
+		BNDebuggerFreeString(event->reg);
+		event->reg = nullptr;
+	}
+}
+
 BNDebuggerTTDBookmark* BNDebuggerGetTTDBookmarks(BNDebuggerController* controller, size_t* count)
 {
 	auto bookmarks = controller->object->GetTTDBookmarks();

--- a/core/ffi.cpp
+++ b/core/ffi.cpp
@@ -1563,11 +1563,11 @@ bool BNDebuggerGetTTDNextRegisterWrite(BNDebuggerController* controller,
 	if (!reg || !result)
 		return false;
 
-	auto [success, event] = controller->object->GetTTDNextRegisterWrite(reg);
-	if (!success)
+	auto event = controller->object->GetTTDNextRegisterWrite(reg);
+	if (!event)
 		return false;
 
-	FillTTDRegisterWriteEvent(event, result);
+	FillTTDRegisterWriteEvent(*event, result);
 	return true;
 }
 
@@ -1577,11 +1577,11 @@ bool BNDebuggerGetTTDPrevRegisterWrite(BNDebuggerController* controller,
 	if (!reg || !result)
 		return false;
 
-	auto [success, event] = controller->object->GetTTDPrevRegisterWrite(reg);
-	if (!success)
+	auto event = controller->object->GetTTDPrevRegisterWrite(reg);
+	if (!event)
 		return false;
 
-	FillTTDRegisterWriteEvent(event, result);
+	FillTTDRegisterWriteEvent(*event, result);
 	return true;
 }
 

--- a/docs/guide/dbgeng-ttd.md
+++ b/docs/guide/dbgeng-ttd.md
@@ -360,6 +360,28 @@ End Address: 0x00401456
 Access Types: Execute only
 ```
 
+### Register Write Navigation
+
+Register write navigation answers the common question "where was this register last written?". It time-travels to the previous or next position at which a register's value changed, equivalent to WinDbg's `!tt br <reg>` command and the `dx @$curthread.TTD.PrevRegisterWrite("<reg>")` / `NextRegisterWrite("<reg>")` data-model methods.
+
+> **Note**: This detects when a register *changes* value, not every architectural write. Writing the same value a register already holds is not reported, so keep this in mind during data-flow analysis.
+
+**From the Registers widget:**
+
+- Right-click a register in the debugger `Registers` widget
+- Select `Go to Previous Write` or `Go to Next Write`
+- The debugger time-travels to the position where that register's value last changed (or next changes), updating the registers and disassembly views
+
+**From the disassembly (graph/linear) or hex view:**
+
+- Right-click directly on a register token (e.g. `rax`) in the code
+- Select `Debugger` -> `Go to Previous Register Write` or `Go to Next Register Write`
+- These entries are only enabled when the cursor is on a register token during a TTD session
+
+If no matching write exists in the trace (or the register was never written), a message is logged to the console and the current position is left unchanged.
+
+The same capability is available programmatically through the Python API via `get_ttd_prev_register_write()` and `get_ttd_next_register_write()` — see [TTD Python API](ttd-python-api.md).
+
 ### TTD Events Widget
 
 The TTD Events widget displays important events that occurred during the TTD trace, such as thread creation/termination, module loads/unloads, and exceptions. This is equivalent to WinDbg's `dx @$cursession.TTD.Events()` functionality.
@@ -581,6 +603,12 @@ if dbg.is_ttd:
     # Query memory writes to an address range
     events = dbg.get_ttd_memory_access_for_address(0x401000, 0x401004, "w")
     print(f"Found {len(events)} writes to 0x401000-0x401004")
+
+    # Find where rax was last written, then time-travel there
+    write = dbg.get_ttd_prev_register_write("rax")
+    if write is not None:
+        print(f"rax changed to {write.value:#x} at {write.position}")
+        dbg.set_ttd_position(write.position)
 ```
 
 ## Additional Resources

--- a/docs/guide/ttd-python-api.md
+++ b/docs/guide/ttd-python-api.md
@@ -62,6 +62,27 @@ class TTDMemoryEvent:
     """
 ```
 
+### TTDRegisterWriteEvent
+
+Represents the result of a register-write query (`PrevRegisterWrite`/`NextRegisterWrite`), i.e. the position at which a register's value last changed.
+
+```python
+class TTDRegisterWriteEvent:
+    """
+    TTDRegisterWriteEvent represents the point at which a register's value changed.
+
+    Attributes:
+        reg (str): Name of the register that was queried (e.g. "rax")
+        position (TTDPosition): TTD position at which the register value changed
+        original_position (TTDPosition): TTD position from which the query was issued
+        value (int): Value the register was changed to
+        original_value (int): Value the register held before the change
+        unique_thread_id (int): Unique thread ID that performed the write
+    """
+```
+
+> **Note:** These queries detect when a register *changes* value, not every architectural write. Writing the same value a register already holds is not reported.
+
 ### TTDCallEvent
 
 Represents a function call event in a TTD trace.
@@ -336,7 +357,51 @@ def set_ttd_position(self, position: TTDPosition) -> bool:
     """
 ```
 
+### get_ttd_prev_register_write()
+
+```python
+def get_ttd_prev_register_write(self, reg: str) -> Optional[TTDRegisterWriteEvent]:
+    """
+    Find the previous position at which the given register's value changed, going backward
+    from the current TTD position. Does not move the current position.
+
+    Args:
+        reg: Name of the register to query (e.g. "rax")
+
+    Returns:
+        TTDRegisterWriteEvent if found, None if no prior write exists
+    """
+```
+
+### get_ttd_next_register_write()
+
+```python
+def get_ttd_next_register_write(self, reg: str) -> Optional[TTDRegisterWriteEvent]:
+    """
+    Find the next position at which the given register's value changes, starting from the
+    current TTD position. Does not move the current position.
+
+    Args:
+        reg: Name of the register to query (e.g. "rax")
+
+    Returns:
+        TTDRegisterWriteEvent if found, None if no subsequent write exists
+    """
+```
+
 ## Usage Examples
+
+### Register Write Analysis
+
+```python
+# "Where was rax last written?" — find and travel to the previous write of rax
+event = dbg.get_ttd_prev_register_write("rax")
+if event is not None:
+    print(f"rax changed to {event.value:#x} at {event.position}")
+    dbg.set_ttd_position(event.position)
+else:
+    print("No previous write of rax found")
+```
 
 ### Basic TTD Check
 

--- a/ui/registerswidget.cpp
+++ b/ui/registerswidget.cpp
@@ -976,18 +976,18 @@ void DebugRegistersWidget::goToRegisterWrite(bool forward)
 	if (!selectedRegisterName(reg))
 		return;
 
-	auto [success, event] =
+	auto event =
 		forward ? m_controller->GetTTDNextRegisterWrite(reg) : m_controller->GetTTDPrevRegisterWrite(reg);
 
 	// A failed query (or a zero position) means there is no such write in the trace. Note that
 	// TTD reports register value *changes*, so a write of the same value is not detected.
-	if (!success || (event.position.sequence == 0 && event.position.step == 0))
+	if (!event || (event->position.sequence == 0 && event->position.step == 0))
 	{
 		LogWarn("No %s write found for register '%s'", forward ? "next" : "previous", reg.c_str());
 		return;
 	}
 
-	if (!m_controller->SetTTDPosition(event.position))
+	if (!m_controller->SetTTDPosition(event->position))
 	{
 		LogWarn("Found %s write for register '%s' but failed to time travel to it",
 			forward ? "next" : "previous", reg.c_str());

--- a/ui/registerswidget.cpp
+++ b/ui/registerswidget.cpp
@@ -466,6 +466,19 @@ DebugRegistersWidget::DebugRegistersWidget(ViewFrame* view, BinaryViewRef data, 
 		return selectionModel()->selectedRows().size() == 1;
 	}));
 
+	actionName = QString::fromStdString("Go to Previous Write");
+	UIAction::registerAction(actionName);
+	m_menu->addAction(actionName, "TTD", MENU_ORDER_FIRST);
+	m_menu->setGroupOrdering("TTD", MENU_ORDER_FIRST);
+	m_actionHandler.bindAction(actionName,
+		UIAction([this]() { goToPrevRegisterWrite(); }, [this]() { return ttdSingleRegisterSelected(); }));
+
+	actionName = QString::fromStdString("Go to Next Write");
+	UIAction::registerAction(actionName);
+	m_menu->addAction(actionName, "TTD", MENU_ORDER_FIRST);
+	m_actionHandler.bindAction(actionName,
+		UIAction([this]() { goToNextRegisterWrite(); }, [this]() { return ttdSingleRegisterSelected(); }));
+
 	actionName = QString::fromStdString("Jump to Address");
 	UIAction::registerAction(actionName);
 	m_menu->addAction(actionName, "Options", MENU_ORDER_FIRST);
@@ -927,6 +940,70 @@ void DebugRegistersWidget::editValue()
 		return;
 
 	edit(cell);
+}
+
+
+bool DebugRegistersWidget::selectedRegisterName(std::string& name)
+{
+	QModelIndexList sel = selectionModel()->selectedRows();
+	if (sel.size() != 1)
+		return false;
+
+	auto sourceIndex = m_filter->mapToSource(sel[0]);
+	if (!sourceIndex.isValid())
+		return false;
+
+	name = m_model->getRow(sourceIndex.row()).name();
+	return !name.empty();
+}
+
+
+bool DebugRegistersWidget::ttdSingleRegisterSelected()
+{
+	if (!m_controller || !m_controller->IsConnected() || !m_controller->IsTTD())
+		return false;
+
+	return selectionModel()->selectedRows().size() == 1;
+}
+
+
+void DebugRegistersWidget::goToRegisterWrite(bool forward)
+{
+	if (!m_controller || !m_controller->IsTTD())
+		return;
+
+	std::string reg;
+	if (!selectedRegisterName(reg))
+		return;
+
+	auto [success, event] =
+		forward ? m_controller->GetTTDNextRegisterWrite(reg) : m_controller->GetTTDPrevRegisterWrite(reg);
+
+	// A failed query (or a zero position) means there is no such write in the trace. Note that
+	// TTD reports register value *changes*, so a write of the same value is not detected.
+	if (!success || (event.position.sequence == 0 && event.position.step == 0))
+	{
+		LogWarn("No %s write found for register '%s'", forward ? "next" : "previous", reg.c_str());
+		return;
+	}
+
+	if (!m_controller->SetTTDPosition(event.position))
+	{
+		LogWarn("Found %s write for register '%s' but failed to time travel to it",
+			forward ? "next" : "previous", reg.c_str());
+	}
+}
+
+
+void DebugRegistersWidget::goToPrevRegisterWrite()
+{
+	goToRegisterWrite(false);
+}
+
+
+void DebugRegistersWidget::goToNextRegisterWrite()
+{
+	goToRegisterWrite(true);
 }
 
 

--- a/ui/registerswidget.h
+++ b/ui/registerswidget.h
@@ -190,6 +190,10 @@ class DebugRegistersWidget : public QTableView, public FilterTarget
 
 	void startHoverTimer(QMouseEvent* event);
 
+	bool selectedRegisterName(std::string& name);
+	bool ttdSingleRegisterSelected();
+	void goToRegisterWrite(bool forward);
+
 public:
 	DebugRegistersWidget(ViewFrame* view, BinaryViewRef data, Menu* menu);
 	void notifyRegistersChanged(std::vector<DebugRegister> regs);
@@ -204,6 +208,8 @@ private slots:
 	void copyRows();
 	void paste();
 	void editValue();
+	void goToPrevRegisterWrite();
+	void goToNextRegisterWrite();
 	void onDoubleClicked();
 	void hoverTimerEvent();
 

--- a/ui/ui.cpp
+++ b/ui/ui.cpp
@@ -301,6 +301,38 @@ void GlobalDebuggerUI::ShowTTDMemoryAccessNextPrevDialog(const UIActionContext& 
 }
 
 
+void GlobalDebuggerUI::GoToRegisterWrite(const UIActionContext& ctxt, bool forward)
+{
+	if (!ctxt.binaryView || !ctxt.token.valid || ctxt.token.type != RegisterToken)
+		return;
+
+	auto controller = DebuggerController::GetController(ctxt.binaryView);
+	if (!controller || !controller->IsConnected() || !controller->IsTTD())
+		return;
+
+	std::string reg = ctxt.token.token.text;
+	if (reg.empty())
+		return;
+
+	auto [success, event] =
+		forward ? controller->GetTTDNextRegisterWrite(reg) : controller->GetTTDPrevRegisterWrite(reg);
+
+	// A failed query (or a zero position) means there is no such write in the trace. Note that
+	// TTD reports register value *changes*, so a write of the same value is not detected.
+	if (!success || (event.position.sequence == 0 && event.position.step == 0))
+	{
+		LogWarn("No %s write found for register '%s'", forward ? "next" : "previous", reg.c_str());
+		return;
+	}
+
+	if (!controller->SetTTDPosition(event.position))
+	{
+		LogWarn("Found %s write for register '%s' but failed to time travel to it",
+			forward ? "next" : "previous", reg.c_str());
+	}
+}
+
+
 void GlobalDebuggerUI::QueryTTDCalls(const UIActionContext& ctxt, const std::string& symbols, uint64_t startReturnAddr, uint64_t endReturnAddr)
 {
 	// Focus the TTD Calls sidebar widget
@@ -1388,6 +1420,23 @@ void GlobalDebuggerUI::SetupMenu(UIContext* context)
 			},
 			connectedToTTD));
 	debuggerMenu->addAction("TTD Memory Access (Next/Prev)", "TTD");
+
+	// TTD Register Write navigation — available when right-clicking a register token in a TTD session
+	auto registerTokenInTTD = [connectedToTTD](const UIActionContext& ctxt) {
+		if (!ctxt.token.valid || ctxt.token.type != RegisterToken)
+			return false;
+		return connectedToTTD(ctxt);
+	};
+
+	UIAction::registerAction("Go to Previous Register Write");
+	context->globalActions()->bindAction("Go to Previous Register Write",
+		UIAction([=, this](const UIActionContext& ctxt) { GoToRegisterWrite(ctxt, false); }, registerTokenInTTD));
+	debuggerMenu->addAction("Go to Previous Register Write", "TTD");
+
+	UIAction::registerAction("Go to Next Register Write");
+	context->globalActions()->bindAction("Go to Next Register Write",
+		UIAction([=, this](const UIActionContext& ctxt) { GoToRegisterWrite(ctxt, true); }, registerTokenInTTD));
+	debuggerMenu->addAction("Go to Next Register Write", "TTD");
 
 	// TTD Calls menu actions
 	UIAction::registerAction("TTD Calls\\Kernel32 Calls");

--- a/ui/ui.cpp
+++ b/ui/ui.cpp
@@ -314,18 +314,18 @@ void GlobalDebuggerUI::GoToRegisterWrite(const UIActionContext& ctxt, bool forwa
 	if (reg.empty())
 		return;
 
-	auto [success, event] =
+	auto event =
 		forward ? controller->GetTTDNextRegisterWrite(reg) : controller->GetTTDPrevRegisterWrite(reg);
 
 	// A failed query (or a zero position) means there is no such write in the trace. Note that
 	// TTD reports register value *changes*, so a write of the same value is not detected.
-	if (!success || (event.position.sequence == 0 && event.position.step == 0))
+	if (!event || (event->position.sequence == 0 && event->position.step == 0))
 	{
 		LogWarn("No %s write found for register '%s'", forward ? "next" : "previous", reg.c_str());
 		return;
 	}
 
-	if (!controller->SetTTDPosition(event.position))
+	if (!controller->SetTTDPosition(event->position))
 	{
 		LogWarn("Found %s write for register '%s' but failed to time travel to it",
 			forward ? "next" : "previous", reg.c_str());

--- a/ui/ui.h
+++ b/ui/ui.h
@@ -60,6 +60,7 @@ public:
 	void GetAddressRange(const UIActionContext& ctxt, uint64_t& startAddr, uint64_t& endAddr);
 	void QueryTTDMemoryAccess(const UIActionContext& ctxt, uint64_t startAddr, uint64_t endAddr, BNDebuggerTTDMemoryAccessType accessType);
 	void ShowTTDMemoryAccessNextPrevDialog(const UIActionContext& ctxt, uint64_t startAddr, uint64_t endAddr);
+	void GoToRegisterWrite(const UIActionContext& ctxt, bool forward);
 	void QueryTTDCalls(const UIActionContext& ctxt, const std::string& symbols, uint64_t startReturnAddr = 0, uint64_t endReturnAddr = 0);
 
 	void SetDisplayingGlobalAreaWidgets(bool display);

--- a/ui/uinotification.cpp
+++ b/ui/uinotification.cpp
@@ -202,6 +202,9 @@ void NotificationListener::OnContextMenuCreated(UIContext *context, View* view, 
 	menu.addAction("Debugger", "TTD Memory Access\\Read/Write/Execute", "TTD");
 	// TTD Memory Access (Next/Prev) — single dialog entry
 	menu.addAction("Debugger", "TTD Memory Access (Next/Prev)", "TTD");
+	// TTD Register Write navigation — only enabled when a register token is under the cursor
+	menu.addAction("Debugger", "Go to Previous Register Write", "TTD");
+	menu.addAction("Debugger", "Go to Next Register Write", "TTD");
 	// TTD Calls context menu item
 	menu.addAction("Debugger", "TTD Calls\\Kernel32 Calls", "TTD");
 }


### PR DESCRIPTION
Fixes #1123.

Adds "go to previous/next register write" for TTD — locate and time-travel to where a register's value last changed, via the dbgeng `PrevRegisterWrite`/`NextRegisterWrite` data-model methods.

- Right-click a register in the **Registers** widget → *Go to Previous/Next Write*
- Right-click a register token in the **graph/linear/hex** view → *Debugger → Go to Previous/Next Register Write*
- C++/Python APIs: `get_ttd_prev/next_register_write()`
- Docs updated (`dbgeng-ttd.md`, `ttd-python-api.md`)

Note: TTD reports register value *changes*, not every architectural write.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
