### PR TITLE
Skip the adapter settings dialog on subsequent debug sessions

### DIFF
--- a/api/debuggerapi.h
+++ b/api/debuggerapi.h
@@ -890,6 +890,16 @@ namespace BinaryNinjaDebuggerAPI {
 		bool IsFirstConnectToDebugServer();
 		bool IsFirstAttach();
 
+		bool ShouldShowAdapterSettingsNextLaunch();
+		bool ShouldShowAdapterSettingsNextAttach();
+		bool ShouldShowAdapterSettingsNextConnect();
+		bool ShouldShowAdapterSettingsNextConnectToDebugServer();
+
+		void SetShowAdapterSettingsNextLaunch(bool value);
+		void SetShowAdapterSettingsNextAttach(bool value);
+		void SetShowAdapterSettingsNextConnect(bool value);
+		void SetShowAdapterSettingsNextConnectToDebugServer(bool value);
+
 		bool IsTTD();
 
 		// TTD Memory Analysis Methods

--- a/api/debuggerapi.h
+++ b/api/debuggerapi.h
@@ -890,15 +890,13 @@ namespace BinaryNinjaDebuggerAPI {
 		bool IsFirstConnectToDebugServer();
 		bool IsFirstAttach();
 
-		bool ShouldShowAdapterSettingsNextLaunch();
-		bool ShouldShowAdapterSettingsNextAttach();
-		bool ShouldShowAdapterSettingsNextConnect();
-		bool ShouldShowAdapterSettingsNextConnectToDebugServer();
+		bool ShouldShowAdapterSettingsForLaunch();
+		bool ShouldShowAdapterSettingsForAttach();
+		bool ShouldShowAdapterSettingsForConnect();
+		bool ShouldShowAdapterSettingsForConnectToDebugServer();
 
-		void SetShowAdapterSettingsNextLaunch(bool value);
-		void SetShowAdapterSettingsNextAttach(bool value);
-		void SetShowAdapterSettingsNextConnect(bool value);
-		void SetShowAdapterSettingsNextConnectToDebugServer(bool value);
+		bool ShowAdapterSettingsNextTime();
+		void SetShowAdapterSettingsNextTime(bool value);
 
 		bool IsTTD();
 

--- a/api/debuggercontroller.cpp
+++ b/api/debuggercontroller.cpp
@@ -1286,6 +1286,54 @@ bool DebuggerController::IsFirstAttach()
 }
 
 
+bool DebuggerController::ShouldShowAdapterSettingsNextLaunch()
+{
+	return BNDebuggerShouldShowAdapterSettingsNextLaunch(m_object);
+}
+
+
+bool DebuggerController::ShouldShowAdapterSettingsNextAttach()
+{
+	return BNDebuggerShouldShowAdapterSettingsNextAttach(m_object);
+}
+
+
+bool DebuggerController::ShouldShowAdapterSettingsNextConnect()
+{
+	return BNDebuggerShouldShowAdapterSettingsNextConnect(m_object);
+}
+
+
+bool DebuggerController::ShouldShowAdapterSettingsNextConnectToDebugServer()
+{
+	return BNDebuggerShouldShowAdapterSettingsNextConnectToDebugServer(m_object);
+}
+
+
+void DebuggerController::SetShowAdapterSettingsNextLaunch(bool value)
+{
+	BNDebuggerSetShowAdapterSettingsNextLaunch(m_object, value);
+}
+
+
+void DebuggerController::SetShowAdapterSettingsNextAttach(bool value)
+{
+	BNDebuggerSetShowAdapterSettingsNextAttach(m_object, value);
+}
+
+
+void DebuggerController::SetShowAdapterSettingsNextConnect(bool value)
+{
+	BNDebuggerSetShowAdapterSettingsNextConnect(m_object, value);
+}
+
+
+void DebuggerController::SetShowAdapterSettingsNextConnectToDebugServer(bool value)
+{
+	BNDebuggerSetShowAdapterSettingsNextConnectToDebugServer(m_object, value);
+}
+
+
 bool DebuggerController::IsTTD()
 {
 	return BNDebuggerIsTTD(m_object);

--- a/api/debuggercontroller.cpp
+++ b/api/debuggercontroller.cpp
@@ -1286,51 +1286,39 @@ bool DebuggerController::IsFirstAttach()
 }
 
 
-bool DebuggerController::ShouldShowAdapterSettingsNextLaunch()
+bool DebuggerController::ShouldShowAdapterSettingsForLaunch()
 {
-	return BNDebuggerShouldShowAdapterSettingsNextLaunch(m_object);
+	return BNDebuggerShouldShowAdapterSettingsForLaunch(m_object);
 }
 
 
-bool DebuggerController::ShouldShowAdapterSettingsNextAttach()
+bool DebuggerController::ShouldShowAdapterSettingsForAttach()
 {
-	return BNDebuggerShouldShowAdapterSettingsNextAttach(m_object);
+	return BNDebuggerShouldShowAdapterSettingsForAttach(m_object);
 }
 
 
-bool DebuggerController::ShouldShowAdapterSettingsNextConnect()
+bool DebuggerController::ShouldShowAdapterSettingsForConnect()
 {
-	return BNDebuggerShouldShowAdapterSettingsNextConnect(m_object);
+	return BNDebuggerShouldShowAdapterSettingsForConnect(m_object);
 }
 
 
-bool DebuggerController::ShouldShowAdapterSettingsNextConnectToDebugServer()
+bool DebuggerController::ShouldShowAdapterSettingsForConnectToDebugServer()
 {
-	return BNDebuggerShouldShowAdapterSettingsNextConnectToDebugServer(m_object);
+	return BNDebuggerShouldShowAdapterSettingsForConnectToDebugServer(m_object);
 }
 
 
-void DebuggerController::SetShowAdapterSettingsNextLaunch(bool value)
+bool DebuggerController::ShowAdapterSettingsNextTime()
 {
-	BNDebuggerSetShowAdapterSettingsNextLaunch(m_object, value);
+	return BNDebuggerShowAdapterSettingsNextTime(m_object);
 }
 
 
-void DebuggerController::SetShowAdapterSettingsNextAttach(bool value)
+void DebuggerController::SetShowAdapterSettingsNextTime(bool value)
 {
-	BNDebuggerSetShowAdapterSettingsNextAttach(m_object, value);
-}
-
-
-void DebuggerController::SetShowAdapterSettingsNextConnect(bool value)
-{
-	BNDebuggerSetShowAdapterSettingsNextConnect(m_object, value);
-}
-
-
-void DebuggerController::SetShowAdapterSettingsNextConnectToDebugServer(bool value)
-{
-	BNDebuggerSetShowAdapterSettingsNextConnectToDebugServer(m_object, value);
+	BNDebuggerSetShowAdapterSettingsNextTime(m_object, value);
 }
 
 

--- a/api/ffi.h
+++ b/api/ffi.h
@@ -754,6 +754,16 @@ extern "C"
 	DEBUGGER_FFI_API bool BNDebuggerIsFirstConnectToDebugServer(BNDebuggerController* controller);
 	DEBUGGER_FFI_API bool BNDebuggerIsFirstAttach(BNDebuggerController* controller);
 
+	DEBUGGER_FFI_API bool BNDebuggerShouldShowAdapterSettingsNextLaunch(BNDebuggerController* controller);
+	DEBUGGER_FFI_API bool BNDebuggerShouldShowAdapterSettingsNextAttach(BNDebuggerController* controller);
+	DEBUGGER_FFI_API bool BNDebuggerShouldShowAdapterSettingsNextConnect(BNDebuggerController* controller);
+	DEBUGGER_FFI_API bool BNDebuggerShouldShowAdapterSettingsNextConnectToDebugServer(BNDebuggerController* controller);
+
+	DEBUGGER_FFI_API void BNDebuggerSetShowAdapterSettingsNextLaunch(BNDebuggerController* controller, bool value);
+	DEBUGGER_FFI_API void BNDebuggerSetShowAdapterSettingsNextAttach(BNDebuggerController* controller, bool value);
+	DEBUGGER_FFI_API void BNDebuggerSetShowAdapterSettingsNextConnect(BNDebuggerController* controller, bool value);
+	DEBUGGER_FFI_API void BNDebuggerSetShowAdapterSettingsNextConnectToDebugServer(BNDebuggerController* controller, bool value);
+
 	DEBUGGER_FFI_API bool BNDebuggerIsTTD(BNDebuggerController* controller);
 
 	// TTD Memory Analysis Functions

--- a/api/ffi.h
+++ b/api/ffi.h
@@ -754,15 +754,13 @@ extern "C"
 	DEBUGGER_FFI_API bool BNDebuggerIsFirstConnectToDebugServer(BNDebuggerController* controller);
 	DEBUGGER_FFI_API bool BNDebuggerIsFirstAttach(BNDebuggerController* controller);
 
-	DEBUGGER_FFI_API bool BNDebuggerShouldShowAdapterSettingsNextLaunch(BNDebuggerController* controller);
-	DEBUGGER_FFI_API bool BNDebuggerShouldShowAdapterSettingsNextAttach(BNDebuggerController* controller);
-	DEBUGGER_FFI_API bool BNDebuggerShouldShowAdapterSettingsNextConnect(BNDebuggerController* controller);
-	DEBUGGER_FFI_API bool BNDebuggerShouldShowAdapterSettingsNextConnectToDebugServer(BNDebuggerController* controller);
+	DEBUGGER_FFI_API bool BNDebuggerShouldShowAdapterSettingsForLaunch(BNDebuggerController* controller);
+	DEBUGGER_FFI_API bool BNDebuggerShouldShowAdapterSettingsForAttach(BNDebuggerController* controller);
+	DEBUGGER_FFI_API bool BNDebuggerShouldShowAdapterSettingsForConnect(BNDebuggerController* controller);
+	DEBUGGER_FFI_API bool BNDebuggerShouldShowAdapterSettingsForConnectToDebugServer(BNDebuggerController* controller);
 
-	DEBUGGER_FFI_API void BNDebuggerSetShowAdapterSettingsNextLaunch(BNDebuggerController* controller, bool value);
-	DEBUGGER_FFI_API void BNDebuggerSetShowAdapterSettingsNextAttach(BNDebuggerController* controller, bool value);
-	DEBUGGER_FFI_API void BNDebuggerSetShowAdapterSettingsNextConnect(BNDebuggerController* controller, bool value);
-	DEBUGGER_FFI_API void BNDebuggerSetShowAdapterSettingsNextConnectToDebugServer(BNDebuggerController* controller, bool value);
+	DEBUGGER_FFI_API bool BNDebuggerShowAdapterSettingsNextTime(BNDebuggerController* controller);
+	DEBUGGER_FFI_API void BNDebuggerSetShowAdapterSettingsNextTime(BNDebuggerController* controller, bool value);
 
 	DEBUGGER_FFI_API bool BNDebuggerIsTTD(BNDebuggerController* controller);
 

--- a/core/debuggercontroller.cpp
+++ b/core/debuggercontroller.cpp
@@ -369,6 +369,7 @@ DebugStopReason DebuggerController::LaunchAndWaitInternal()
 	}
 
 	m_firstLaunch = false;
+	m_lastDebugStartOperation = LaunchStartOperation;
 
 	DebuggerEvent event;
 	event.type = LaunchEventType;
@@ -421,6 +422,7 @@ bool DebuggerController::Attach()
 DebugStopReason DebuggerController::AttachAndWaitInternal()
 {
 	m_firstAttach = false;
+	m_lastDebugStartOperation = AttachStartOperation;
 
 	DebuggerEvent event;
 	event.type = LaunchEventType;
@@ -473,6 +475,7 @@ bool DebuggerController::Connect()
 DebugStopReason DebuggerController::ConnectAndWaitInternal()
 {
 	m_firstConnect = false;
+	m_lastDebugStartOperation = ConnectStartOperation;
 
 	DebuggerEvent event;
 	event.type = LaunchEventType;
@@ -1685,6 +1688,7 @@ DebugStopReason DebuggerController::RestartAndWait(std::chrono::milliseconds tim
 bool DebuggerController::ConnectToDebugServer()
 {
 	m_firstConnectToDebugServer = false;
+	m_lastDebugStartOperation = ConnectToDebugServerStartOperation;
 	if (m_state->IsConnectedToDebugServer())
 		return true;
 
@@ -3789,51 +3793,39 @@ bool DebuggerController::IsFirstAttach()
 }
 
 
-bool DebuggerController::ShouldShowAdapterSettingsNextLaunch()
+bool DebuggerController::ShouldShowAdapterSettingsForLaunch()
 {
-	return m_showAdapterSettingsNextLaunch;
+	return m_lastDebugStartOperation != LaunchStartOperation || m_showAdapterSettingsNextTime;
 }
 
 
-bool DebuggerController::ShouldShowAdapterSettingsNextAttach()
+bool DebuggerController::ShouldShowAdapterSettingsForAttach()
 {
-	return m_showAdapterSettingsNextAttach;
+	return m_lastDebugStartOperation != AttachStartOperation || m_showAdapterSettingsNextTime;
 }
 
 
-bool DebuggerController::ShouldShowAdapterSettingsNextConnect()
+bool DebuggerController::ShouldShowAdapterSettingsForConnect()
 {
-	return m_showAdapterSettingsNextConnect;
+	return m_lastDebugStartOperation != ConnectStartOperation || m_showAdapterSettingsNextTime;
 }
 
 
-bool DebuggerController::ShouldShowAdapterSettingsNextConnectToDebugServer()
+bool DebuggerController::ShouldShowAdapterSettingsForConnectToDebugServer()
 {
-	return m_showAdapterSettingsNextConnectToDebugServer;
+	return m_lastDebugStartOperation != ConnectToDebugServerStartOperation || m_showAdapterSettingsNextTime;
 }
 
 
-void DebuggerController::SetShowAdapterSettingsNextLaunch(bool value)
+bool DebuggerController::ShowAdapterSettingsNextTime()
 {
-	m_showAdapterSettingsNextLaunch = value;
+	return m_showAdapterSettingsNextTime;
 }
 
 
-void DebuggerController::SetShowAdapterSettingsNextAttach(bool value)
+void DebuggerController::SetShowAdapterSettingsNextTime(bool value)
 {
-	m_showAdapterSettingsNextAttach = value;
-}
-
-
-void DebuggerController::SetShowAdapterSettingsNextConnect(bool value)
-{
-	m_showAdapterSettingsNextConnect = value;
-}
-
-
-void DebuggerController::SetShowAdapterSettingsNextConnectToDebugServer(bool value)
-{
-	m_showAdapterSettingsNextConnectToDebugServer = value;
+	m_showAdapterSettingsNextTime = value;
 }
 
 

--- a/core/debuggercontroller.cpp
+++ b/core/debuggercontroller.cpp
@@ -3789,6 +3789,54 @@ bool DebuggerController::IsFirstAttach()
 }
 
 
+bool DebuggerController::ShouldShowAdapterSettingsNextLaunch()
+{
+	return m_showAdapterSettingsNextLaunch;
+}
+
+
+bool DebuggerController::ShouldShowAdapterSettingsNextAttach()
+{
+	return m_showAdapterSettingsNextAttach;
+}
+
+
+bool DebuggerController::ShouldShowAdapterSettingsNextConnect()
+{
+	return m_showAdapterSettingsNextConnect;
+}
+
+
+bool DebuggerController::ShouldShowAdapterSettingsNextConnectToDebugServer()
+{
+	return m_showAdapterSettingsNextConnectToDebugServer;
+}
+
+
+void DebuggerController::SetShowAdapterSettingsNextLaunch(bool value)
+{
+	m_showAdapterSettingsNextLaunch = value;
+}
+
+
+void DebuggerController::SetShowAdapterSettingsNextAttach(bool value)
+{
+	m_showAdapterSettingsNextAttach = value;
+}
+
+
+void DebuggerController::SetShowAdapterSettingsNextConnect(bool value)
+{
+	m_showAdapterSettingsNextConnect = value;
+}
+
+
+void DebuggerController::SetShowAdapterSettingsNextConnectToDebugServer(bool value)
+{
+	m_showAdapterSettingsNextConnectToDebugServer = value;
+}
+
+
 bool DebuggerController::IsTTD()
 {
 	if(!m_adapter)

--- a/core/debuggercontroller.h
+++ b/core/debuggercontroller.h
@@ -175,6 +175,11 @@ namespace BinaryNinjaDebugger {
 		bool m_firstConnectToDebugServer = true;
 		bool m_firstAttach = true;
 
+		bool m_showAdapterSettingsNextLaunch = true;
+		bool m_showAdapterSettingsNextAttach = true;
+		bool m_showAdapterSettingsNextConnect = true;
+		bool m_showAdapterSettingsNextConnectToDebugServer = true;
+
 		bool m_shouldAnnotateStackVariable = false;
 
 		// Apply the controller's own state mutations for each event type. Called inline
@@ -644,6 +649,17 @@ namespace BinaryNinjaDebugger {
 		bool IsFirstConnect();
 		bool IsFirstConnectToDebugServer();
 		bool IsFirstAttach();
+
+		bool ShouldShowAdapterSettingsNextLaunch();
+		bool ShouldShowAdapterSettingsNextAttach();
+		bool ShouldShowAdapterSettingsNextConnect();
+		bool ShouldShowAdapterSettingsNextConnectToDebugServer();
+
+		void SetShowAdapterSettingsNextLaunch(bool value);
+		void SetShowAdapterSettingsNextAttach(bool value);
+		void SetShowAdapterSettingsNextConnect(bool value);
+		void SetShowAdapterSettingsNextConnectToDebugServer(bool value);
+
 		bool IsTTD();
 
 		// TTD Memory Analysis Methods

--- a/core/debuggercontroller.h
+++ b/core/debuggercontroller.h
@@ -175,10 +175,19 @@ namespace BinaryNinjaDebugger {
 		bool m_firstConnectToDebugServer = true;
 		bool m_firstAttach = true;
 
-		bool m_showAdapterSettingsNextLaunch = true;
-		bool m_showAdapterSettingsNextAttach = true;
-		bool m_showAdapterSettingsNextConnect = true;
-		bool m_showAdapterSettingsNextConnectToDebugServer = true;
+		// Whether to show the adapter settings dialog before the next debug session is started. When the user starts a
+		// session whose kind differs from m_lastDebugStartOperation we always show the dialog regardless of this flag,
+		// so that switching between e.g. launch and attach never silently reuses stale settings.
+		enum LastDebugStartOperation
+		{
+			NoDebugStartOperation,
+			LaunchStartOperation,
+			AttachStartOperation,
+			ConnectStartOperation,
+			ConnectToDebugServerStartOperation,
+		};
+		bool m_showAdapterSettingsNextTime = true;
+		LastDebugStartOperation m_lastDebugStartOperation = NoDebugStartOperation;
 
 		bool m_shouldAnnotateStackVariable = false;
 
@@ -650,15 +659,13 @@ namespace BinaryNinjaDebugger {
 		bool IsFirstConnectToDebugServer();
 		bool IsFirstAttach();
 
-		bool ShouldShowAdapterSettingsNextLaunch();
-		bool ShouldShowAdapterSettingsNextAttach();
-		bool ShouldShowAdapterSettingsNextConnect();
-		bool ShouldShowAdapterSettingsNextConnectToDebugServer();
+		bool ShouldShowAdapterSettingsForLaunch();
+		bool ShouldShowAdapterSettingsForAttach();
+		bool ShouldShowAdapterSettingsForConnect();
+		bool ShouldShowAdapterSettingsForConnectToDebugServer();
 
-		void SetShowAdapterSettingsNextLaunch(bool value);
-		void SetShowAdapterSettingsNextAttach(bool value);
-		void SetShowAdapterSettingsNextConnect(bool value);
-		void SetShowAdapterSettingsNextConnectToDebugServer(bool value);
+		bool ShowAdapterSettingsNextTime();
+		void SetShowAdapterSettingsNextTime(bool value);
 
 		bool IsTTD();
 

--- a/core/ffi.cpp
+++ b/core/ffi.cpp
@@ -1410,6 +1410,54 @@ bool BNDebuggerIsFirstAttach(BNDebuggerController* controller)
 }
 
 
+bool BNDebuggerShouldShowAdapterSettingsNextLaunch(BNDebuggerController* controller)
+{
+	return controller->object->ShouldShowAdapterSettingsNextLaunch();
+}
+
+
+bool BNDebuggerShouldShowAdapterSettingsNextAttach(BNDebuggerController* controller)
+{
+	return controller->object->ShouldShowAdapterSettingsNextAttach();
+}
+
+
+bool BNDebuggerShouldShowAdapterSettingsNextConnect(BNDebuggerController* controller)
+{
+	return controller->object->ShouldShowAdapterSettingsNextConnect();
+}
+
+
+bool BNDebuggerShouldShowAdapterSettingsNextConnectToDebugServer(BNDebuggerController* controller)
+{
+	return controller->object->ShouldShowAdapterSettingsNextConnectToDebugServer();
+}
+
+
+void BNDebuggerSetShowAdapterSettingsNextLaunch(BNDebuggerController* controller, bool value)
+{
+	controller->object->SetShowAdapterSettingsNextLaunch(value);
+}
+
+
+void BNDebuggerSetShowAdapterSettingsNextAttach(BNDebuggerController* controller, bool value)
+{
+	controller->object->SetShowAdapterSettingsNextAttach(value);
+}
+
+
+void BNDebuggerSetShowAdapterSettingsNextConnect(BNDebuggerController* controller, bool value)
+{
+	controller->object->SetShowAdapterSettingsNextConnect(value);
+}
+
+
+void BNDebuggerSetShowAdapterSettingsNextConnectToDebugServer(BNDebuggerController* controller, bool value)
+{
+	controller->object->SetShowAdapterSettingsNextConnectToDebugServer(value);
+}
+
+
 bool BNDebuggerIsTTD(BNDebuggerController* controller)
 {
 	return controller->object->IsTTD();

--- a/core/ffi.cpp
+++ b/core/ffi.cpp
@@ -1410,51 +1410,39 @@ bool BNDebuggerIsFirstAttach(BNDebuggerController* controller)
 }
 
 
-bool BNDebuggerShouldShowAdapterSettingsNextLaunch(BNDebuggerController* controller)
+bool BNDebuggerShouldShowAdapterSettingsForLaunch(BNDebuggerController* controller)
 {
-	return controller->object->ShouldShowAdapterSettingsNextLaunch();
+	return controller->object->ShouldShowAdapterSettingsForLaunch();
 }
 
 
-bool BNDebuggerShouldShowAdapterSettingsNextAttach(BNDebuggerController* controller)
+bool BNDebuggerShouldShowAdapterSettingsForAttach(BNDebuggerController* controller)
 {
-	return controller->object->ShouldShowAdapterSettingsNextAttach();
+	return controller->object->ShouldShowAdapterSettingsForAttach();
 }
 
 
-bool BNDebuggerShouldShowAdapterSettingsNextConnect(BNDebuggerController* controller)
+bool BNDebuggerShouldShowAdapterSettingsForConnect(BNDebuggerController* controller)
 {
-	return controller->object->ShouldShowAdapterSettingsNextConnect();
+	return controller->object->ShouldShowAdapterSettingsForConnect();
 }
 
 
-bool BNDebuggerShouldShowAdapterSettingsNextConnectToDebugServer(BNDebuggerController* controller)
+bool BNDebuggerShouldShowAdapterSettingsForConnectToDebugServer(BNDebuggerController* controller)
 {
-	return controller->object->ShouldShowAdapterSettingsNextConnectToDebugServer();
+	return controller->object->ShouldShowAdapterSettingsForConnectToDebugServer();
 }
 
 
-void BNDebuggerSetShowAdapterSettingsNextLaunch(BNDebuggerController* controller, bool value)
+bool BNDebuggerShowAdapterSettingsNextTime(BNDebuggerController* controller)
 {
-	controller->object->SetShowAdapterSettingsNextLaunch(value);
+	return controller->object->ShowAdapterSettingsNextTime();
 }
 
 
-void BNDebuggerSetShowAdapterSettingsNextAttach(BNDebuggerController* controller, bool value)
+void BNDebuggerSetShowAdapterSettingsNextTime(BNDebuggerController* controller, bool value)
 {
-	controller->object->SetShowAdapterSettingsNextAttach(value);
-}
-
-
-void BNDebuggerSetShowAdapterSettingsNextConnect(BNDebuggerController* controller, bool value)
-{
-	controller->object->SetShowAdapterSettingsNextConnect(value);
-}
-
-
-void BNDebuggerSetShowAdapterSettingsNextConnectToDebugServer(BNDebuggerController* controller, bool value)
-{
-	controller->object->SetShowAdapterSettingsNextConnectToDebugServer(value);
+	controller->object->SetShowAdapterSettingsNextTime(value);
 }
 
 

--- a/ui/adaptersettings.cpp
+++ b/ui/adaptersettings.cpp
@@ -24,7 +24,7 @@ using namespace BinaryNinja;
 using namespace std;
 
 AdapterSettingsDialog::AdapterSettingsDialog(QWidget* parent, DbgRef<DebuggerController> controller, const std::string& highlightGroup) :
-	QDialog(), m_controller(controller), m_highlightGroup(highlightGroup)
+	QDialog(), m_controller(controller)
 {
 	setWindowTitle("Debug Adapter Settings");
 	setAttribute(Qt::WA_DeleteOnClose);
@@ -67,6 +67,10 @@ AdapterSettingsDialog::AdapterSettingsDialog(QWidget* parent, DbgRef<DebuggerCon
 	m_stack->setCurrentWidget(widget);
 	layout->addWidget(m_stack);
 
+	// Reflect the stored preference: checked means "do not show the dialog next time"
+	m_useSameSettingsCheckbox = new QCheckBox("Use same settings next time");
+	m_useSameSettingsCheckbox->setChecked(!m_controller->ShowAdapterSettingsNextTime());
+
 	if (!highlightGroup.empty())
 	{
 		auto adapterSettings = qobject_cast<SettingsView*>(widget);
@@ -77,9 +81,6 @@ AdapterSettingsDialog::AdapterSettingsDialog(QWidget* parent, DbgRef<DebuggerCon
 
 		QHBoxLayout* buttonLayout = new QHBoxLayout;
 		buttonLayout->setContentsMargins(0, 0, 0, 0);
-
-		m_useSameSettingsCheckbox = new QCheckBox("Use same settings next time");
-		m_useSameSettingsCheckbox->setChecked(true);
 
 		QPushButton* cancelButton = new QPushButton("Cancel");
 		connect(cancelButton, &QPushButton::clicked, [&]() { reject(); });
@@ -95,6 +96,22 @@ AdapterSettingsDialog::AdapterSettingsDialog(QWidget* parent, DbgRef<DebuggerCon
 
 		layout->addSpacing(10);
 		layout->addLayout(buttonLayout);
+	}
+	else
+	{
+		// The generic settings dialog (opened from the menu) has no Accept/Cancel button and applies
+		// settings live, so update the preference immediately whenever the checkbox is toggled. This is
+		// the entry point for re-enabling the dialog after it has been suppressed for an operation.
+		connect(m_useSameSettingsCheckbox, &QCheckBox::toggled, this,
+			[this](bool checked) { m_controller->SetShowAdapterSettingsNextTime(!checked); });
+
+		QHBoxLayout* checkboxLayout = new QHBoxLayout;
+		checkboxLayout->setContentsMargins(0, 0, 0, 0);
+		checkboxLayout->addWidget(m_useSameSettingsCheckbox);
+		checkboxLayout->addStretch(1);
+
+		layout->addSpacing(10);
+		layout->addLayout(checkboxLayout);
 	}
 
 	setLayout(layout);
@@ -144,16 +161,6 @@ QWidget* AdapterSettingsDialog::getWidgetForAdapter(const QString& adapter)
 void AdapterSettingsDialog::apply()
 {
 	if (m_useSameSettingsCheckbox)
-	{
-		bool showAgain = !m_useSameSettingsCheckbox->isChecked();
-		if (m_highlightGroup == "launch")
-			m_controller->SetShowAdapterSettingsNextLaunch(showAgain);
-		else if (m_highlightGroup == "attach")
-			m_controller->SetShowAdapterSettingsNextAttach(showAgain);
-		else if (m_highlightGroup == "connect")
-			m_controller->SetShowAdapterSettingsNextConnect(showAgain);
-		else if (m_highlightGroup == "debug_server")
-			m_controller->SetShowAdapterSettingsNextConnectToDebugServer(showAgain);
-	}
+		m_controller->SetShowAdapterSettingsNextTime(!m_useSameSettingsCheckbox->isChecked());
 	accept();
 }

--- a/ui/adaptersettings.cpp
+++ b/ui/adaptersettings.cpp
@@ -24,7 +24,7 @@ using namespace BinaryNinja;
 using namespace std;
 
 AdapterSettingsDialog::AdapterSettingsDialog(QWidget* parent, DbgRef<DebuggerController> controller, const std::string& highlightGroup) :
-	QDialog(), m_controller(controller)
+	QDialog(), m_controller(controller), m_highlightGroup(highlightGroup)
 {
 	setWindowTitle("Debug Adapter Settings");
 	setAttribute(Qt::WA_DeleteOnClose);
@@ -78,12 +78,16 @@ AdapterSettingsDialog::AdapterSettingsDialog(QWidget* parent, DbgRef<DebuggerCon
 		QHBoxLayout* buttonLayout = new QHBoxLayout;
 		buttonLayout->setContentsMargins(0, 0, 0, 0);
 
+		m_useSameSettingsCheckbox = new QCheckBox("Use same settings next time");
+		m_useSameSettingsCheckbox->setChecked(true);
+
 		QPushButton* cancelButton = new QPushButton("Cancel");
 		connect(cancelButton, &QPushButton::clicked, [&]() { reject(); });
 		QPushButton* acceptButton = new QPushButton("Accept");
 		connect(acceptButton, &QPushButton::clicked, [&]() { apply(); });
 		acceptButton->setDefault(true);
 
+		buttonLayout->addWidget(m_useSameSettingsCheckbox);
 		buttonLayout->addStretch(1);
 		buttonLayout->addWidget(cancelButton);
 		buttonLayout->addSpacing(10);
@@ -139,5 +143,17 @@ QWidget* AdapterSettingsDialog::getWidgetForAdapter(const QString& adapter)
 
 void AdapterSettingsDialog::apply()
 {
+	if (m_useSameSettingsCheckbox)
+	{
+		bool showAgain = !m_useSameSettingsCheckbox->isChecked();
+		if (m_highlightGroup == "launch")
+			m_controller->SetShowAdapterSettingsNextLaunch(showAgain);
+		else if (m_highlightGroup == "attach")
+			m_controller->SetShowAdapterSettingsNextAttach(showAgain);
+		else if (m_highlightGroup == "connect")
+			m_controller->SetShowAdapterSettingsNextConnect(showAgain);
+		else if (m_highlightGroup == "debug_server")
+			m_controller->SetShowAdapterSettingsNextConnectToDebugServer(showAgain);
+	}
 	accept();
 }

--- a/ui/adaptersettings.h
+++ b/ui/adaptersettings.h
@@ -43,7 +43,6 @@ private:
 	QMap<QString, QWidget*> m_viewMap;
 	QLabel* m_noSettingsLabel;
 	QCheckBox* m_useSameSettingsCheckbox = nullptr;
-	std::string m_highlightGroup;
 
 	QWidget* getWidgetForAdapter(const QString& adapter);
 

--- a/ui/adaptersettings.h
+++ b/ui/adaptersettings.h
@@ -42,6 +42,8 @@ private:
 	QStackedWidget* m_stack;
 	QMap<QString, QWidget*> m_viewMap;
 	QLabel* m_noSettingsLabel;
+	QCheckBox* m_useSameSettingsCheckbox = nullptr;
+	std::string m_highlightGroup;
 
 	QWidget* getWidgetForAdapter(const QString& adapter);
 

--- a/ui/controlswidget.cpp
+++ b/ui/controlswidget.cpp
@@ -267,7 +267,7 @@ void DebugControlsWidget::performLaunch()
 		return;
 
 	bool firstLaunch = m_controller->IsFirstLaunch();
-	if (firstLaunch)
+	if (firstLaunch || m_controller->ShouldShowAdapterSettingsNextLaunch())
 	{
 		auto adapterSettings = new AdapterSettingsDialog(this, m_controller, "launch");
 		if (adapterSettings->exec() != QDialog::Accepted)

--- a/ui/controlswidget.cpp
+++ b/ui/controlswidget.cpp
@@ -267,7 +267,7 @@ void DebugControlsWidget::performLaunch()
 		return;
 
 	bool firstLaunch = m_controller->IsFirstLaunch();
-	if (firstLaunch || m_controller->ShouldShowAdapterSettingsNextLaunch())
+	if (m_controller->ShouldShowAdapterSettingsForLaunch())
 	{
 		auto adapterSettings = new AdapterSettingsDialog(this, m_controller, "launch");
 		if (adapterSettings->exec() != QDialog::Accepted)

--- a/ui/ui.cpp
+++ b/ui/ui.cpp
@@ -563,7 +563,7 @@ void GlobalDebuggerUI::SetupMenu(UIContext* context)
 					return;
 
 				bool firstLaunch = controller->IsFirstLaunch();
-                if (firstLaunch)
+                if (firstLaunch || controller->ShouldShowAdapterSettingsNextLaunch())
                 {
                 	auto adapterSettings = new AdapterSettingsDialog(context->mainWindow(), controller, "launch");
                 	if (adapterSettings->exec() != QDialog::Accepted)
@@ -859,7 +859,7 @@ void GlobalDebuggerUI::SetupMenu(UIContext* context)
 				if (!controller)
 					return;
 
-				if (controller->IsFirstAttach())
+				if (controller->IsFirstAttach() || controller->ShouldShowAdapterSettingsNextAttach())
 				{
 					auto adapterSettings = new AdapterSettingsDialog(context->mainWindow(), controller, "attach");
 					if (adapterSettings->exec() != QDialog::Accepted)
@@ -1074,7 +1074,7 @@ void GlobalDebuggerUI::SetupMenu(UIContext* context)
 				if (!controller)
 					return;
 
-                if (controller->IsFirstConnectToDebugServer())
+                if (controller->IsFirstConnectToDebugServer() || controller->ShouldShowAdapterSettingsNextConnectToDebugServer())
                 {
                 	auto adapterSettings = new AdapterSettingsDialog(context->mainWindow(), controller, "debug_server");
                 	if (adapterSettings->exec() != QDialog::Accepted)
@@ -1129,7 +1129,7 @@ void GlobalDebuggerUI::SetupMenu(UIContext* context)
 				if (!controller)
 					return;
 
-				if (controller->IsFirstConnect())
+				if (controller->IsFirstConnect() || controller->ShouldShowAdapterSettingsNextConnect())
 				{
 					auto adapterSettings = new AdapterSettingsDialog(context->mainWindow(), controller, "connect");
 					if (adapterSettings->exec() != QDialog::Accepted)

--- a/ui/ui.cpp
+++ b/ui/ui.cpp
@@ -563,7 +563,7 @@ void GlobalDebuggerUI::SetupMenu(UIContext* context)
 					return;
 
 				bool firstLaunch = controller->IsFirstLaunch();
-                if (firstLaunch || controller->ShouldShowAdapterSettingsNextLaunch())
+                if (controller->ShouldShowAdapterSettingsForLaunch())
                 {
                 	auto adapterSettings = new AdapterSettingsDialog(context->mainWindow(), controller, "launch");
                 	if (adapterSettings->exec() != QDialog::Accepted)
@@ -859,7 +859,7 @@ void GlobalDebuggerUI::SetupMenu(UIContext* context)
 				if (!controller)
 					return;
 
-				if (controller->IsFirstAttach() || controller->ShouldShowAdapterSettingsNextAttach())
+				if (controller->ShouldShowAdapterSettingsForAttach())
 				{
 					auto adapterSettings = new AdapterSettingsDialog(context->mainWindow(), controller, "attach");
 					if (adapterSettings->exec() != QDialog::Accepted)
@@ -1074,7 +1074,7 @@ void GlobalDebuggerUI::SetupMenu(UIContext* context)
 				if (!controller)
 					return;
 
-                if (controller->IsFirstConnectToDebugServer() || controller->ShouldShowAdapterSettingsNextConnectToDebugServer())
+                if (controller->ShouldShowAdapterSettingsForConnectToDebugServer())
                 {
                 	auto adapterSettings = new AdapterSettingsDialog(context->mainWindow(), controller, "debug_server");
                 	if (adapterSettings->exec() != QDialog::Accepted)
@@ -1129,7 +1129,7 @@ void GlobalDebuggerUI::SetupMenu(UIContext* context)
 				if (!controller)
 					return;
 
-				if (controller->IsFirstConnect() || controller->ShouldShowAdapterSettingsNextConnect())
+				if (controller->ShouldShowAdapterSettingsForConnect())
 				{
 					auto adapterSettings = new AdapterSettingsDialog(context->mainWindow(), controller, "connect");
 					if (adapterSettings->exec() != QDialog::Accepted)


### PR DESCRIPTION
## Skip the adapter settings dialog on subsequent debug sessions

Adds a **"Use same settings next time"** checkbox to the Debug Adapter Settings dialog. When checked, the dialog is not shown again the next time you start the debugger with the same operation, so repeated launches/attaches don't re-prompt for settings.

Supersedes #1064 — built on top of @3rdit's original work (credited as co-author). Rebased onto latest `dev`.

### Behavior

The preference is a single flag combined with a record of the **last debug-start operation** (launch / attach / connect / connect-to-debug-server). The dialog is shown when:

- the operation differs from the last one you ran, **or**
- the "use same settings" preference asks for it (i.e. the box was left unchecked).

This avoids a footgun a naive single flag would have: choosing "use same settings" while **launching** must not silently suppress the dialog when you later switch to **attach** — an operation you never configured. Because switching operations always re-prompts, suppression is always explicit and per-kind, while the only inherited direction ("show again") is harmless.

The checkbox reflects and writes this one preference. It also appears in the generic **Debug Adapter Settings** dialog (opened from the menu), which is the entry point for re-enabling a dialog that has been suppressed for an operation.

The preference is in-memory (per debugger session), matching the existing `IsFirstLaunch`/`IsFirstAttach` flags.

### Changes

- **core**: replace the four per-operation "show next time" flags with a single `m_showAdapterSettingsNextTime` plus `m_lastDebugStartOperation`, recorded when each session starts. New `ShouldShowAdapterSettingsFor{Launch,Attach,Connect,ConnectToDebugServer}()` decision helpers and a single `ShowAdapterSettingsNextTime()` getter / `SetShowAdapterSettingsNextTime()` setter.
- **ffi / api**: collapse the eight exported functions to six (four per-op decisions + getter + setter).
- **ui**: dialog gates simplified to `ShouldShowAdapterSettingsFor<Op>()`; checkbox writes the single preference and now also shows in the generic settings dialog (applied live, since that dialog has no OK/Cancel).

### Testing

Manually verified: first launch prompts; a second launch with the box checked skips the dialog; switching to attach re-prompts; unchecking the box in the generic settings dialog re-enables prompting.
