### PR TITLE
Refine double-click navigation while debugging

### DIFF
--- a/ui/uinotification.cpp
+++ b/ui/uinotification.cpp
@@ -271,11 +271,18 @@ bool NotificationListener::OnTokenDoubleClicked(UIContext* context, ViewFrame* f
 	}
 	else if (token.type == DataSymbolToken || token.type == StringToken)
 	{
-		// A data symbol (e.g. data_100003fa9) or an inline string. The default behavior
+		// A data symbol (e.g. data_100003fa9) or a string reference. The default behavior
 		// navigates to it in the same view; while debugging we instead open it in another
-		// pane so the disassembly the user is looking at stays put. The referenced address is
-		// carried in the token's value (the address field is not populated for these tokens).
-		target = token.addrValid ? token.addr : token.token.value;
+		// pane so the disassembly the user is looking at stays put.
+
+		if ((token.type == StringToken) && (token.token.context != StringReferenceTokenContext)
+			&& (token.token.context != StringDataVariableTokenContext))
+			return false;
+
+		if (!token.addrValid)
+			return false;
+
+		target = token.addr;
 		haveTarget = true;
 	}
 	else if (token.type == RegisterToken)
@@ -341,6 +348,5 @@ bool NotificationListener::OnTokenDoubleClicked(UIContext* context, ViewFrame* f
 		return false;
 
 	// Open the target in another pane so the disassembly the user is looking at stays put.
-	view->navigateOnOtherPane(target);
-	return true;
+	return view->navigateOnOtherPane(target);
 }

--- a/ui/uinotification.cpp
+++ b/ui/uinotification.cpp
@@ -269,6 +269,15 @@ bool NotificationListener::OnTokenDoubleClicked(UIContext* context, ViewFrame* f
 		target = token.addr;
 		haveTarget = true;
 	}
+	else if (token.type == DataSymbolToken || token.type == StringToken)
+	{
+		// A data symbol (e.g. data_100003fa9) or an inline string. The default behavior
+		// navigates to it in the same view; while debugging we instead open it in another
+		// pane so the disassembly the user is looking at stays put. The referenced address is
+		// carried in the token's value (the address field is not populated for these tokens).
+		target = token.addrValid ? token.addr : token.token.value;
+		haveTarget = true;
+	}
 	else if (token.type == RegisterToken)
 	{
 		// A raw register token: navigate to the address currently held in the register.

--- a/ui/uinotification.cpp
+++ b/ui/uinotification.cpp
@@ -246,6 +246,26 @@ bool NotificationListener::OnTokenDoubleClicked(UIContext* context, ViewFrame* f
 		// AddressDisplayToken is intentionally left out: those keep navigating in the current view.
 		// NOTE: opening address-valued literals in a new pane is arguably a better default
 		// and should probably become the standard behavior even outside of a debug session.
+
+		// If the target lands inside the function the user is already looking at, they most
+		// likely want to jump to it in place rather than open a second pane. Fall through to
+		// the default double-click behavior (in-pane navigation) in that case.
+		auto func = location.getFunction();
+		if (!func)
+		{
+			auto funcs = data->GetAnalysisFunctionsContainingAddress(location.getOffset());
+			if (!funcs.empty())
+				func = funcs[0];
+		}
+		if (func)
+		{
+			for (const auto& range : func->GetAddressRanges())
+			{
+				if ((token.addr >= range.start) && (token.addr < range.end))
+					return false;
+			}
+		}
+
 		target = token.addr;
 		haveTarget = true;
 	}

--- a/ui/uinotification.cpp
+++ b/ui/uinotification.cpp
@@ -348,5 +348,6 @@ bool NotificationListener::OnTokenDoubleClicked(UIContext* context, ViewFrame* f
 		return false;
 
 	// Open the target in another pane so the disassembly the user is looking at stays put.
-	return view->navigateOnOtherPane(target);
+	view->navigateOnOtherPane(target);
+	return true;
 }


### PR DESCRIPTION
Two fixes to `OnTokenDoubleClicked`:

- **#1136**: Address literals resolving into the current function now navigate in place instead of always opening a second pane. Only out-of-function targets open in another pane.
- **#1137**: Data symbol (e.g. `data_100003fa9`) and inline string tokens now open in another pane while debugging, instead of falling through to default in-pane navigation.

Closes #1136
Closes #1137

🤖 Generated with [Claude Code](https://claude.com/claude-code)