### PR TITLE
Query IDebugDataSpaces2/4 in the TTD adapter

### DIFF
--- a/core/adapters/dbgengadapter.cpp
+++ b/core/adapters/dbgengadapter.cpp
@@ -331,6 +331,7 @@ bool DbgEngAdapter::ConnectToDebugServerInternal(const std::string& connectionSt
 	QUERY_DEBUG_INTERFACE(IDebugControl7, &this->m_debugControl);
 	QUERY_DEBUG_INTERFACE(IDebugDataSpaces, &this->m_debugDataSpaces);
 	QUERY_DEBUG_INTERFACE(IDebugDataSpaces2, &this->m_debugDataSpaces2);
+	QUERY_DEBUG_INTERFACE(IDebugDataSpaces4, &this->m_debugDataSpaces4);
 	QUERY_DEBUG_INTERFACE(IDebugRegisters, &this->m_debugRegisters);
 	QUERY_DEBUG_INTERFACE(IDebugSymbols3, &this->m_debugSymbols);
 	QUERY_DEBUG_INTERFACE(IDebugSystemObjects, &this->m_debugSystemObjects);
@@ -424,6 +425,7 @@ void DbgEngAdapter::Reset()
 		SAFE_RELEASE(this->m_debugControl);
 		SAFE_RELEASE(this->m_debugDataSpaces);
 		SAFE_RELEASE(this->m_debugDataSpaces2);
+		SAFE_RELEASE(this->m_debugDataSpaces4);
 		SAFE_RELEASE(this->m_debugRegisters);
 		SAFE_RELEASE(this->m_debugSymbols);
 		SAFE_RELEASE(this->m_debugSystemObjects);

--- a/core/adapters/dbgengadapter.h
+++ b/core/adapters/dbgengadapter.h
@@ -129,6 +129,7 @@ namespace BinaryNinjaDebugger {
 		IDebugControl7* m_debugControl {nullptr};
 		IDebugDataSpaces* m_debugDataSpaces {nullptr};
 		IDebugDataSpaces2* m_debugDataSpaces2 {nullptr};
+		IDebugDataSpaces4* m_debugDataSpaces4 {nullptr};
 		IDebugRegisters* m_debugRegisters {nullptr};
 		IDebugSymbols3* m_debugSymbols {nullptr};
 		IDebugSystemObjects* m_debugSystemObjects {nullptr};

--- a/core/adapters/dbgengttdadapter.cpp
+++ b/core/adapters/dbgengttdadapter.cpp
@@ -133,6 +133,11 @@ bool DbgEngTTDAdapter::Start()
 
 	QUERY_DEBUG_INTERFACE(IDebugControl7, &this->m_debugControl);
 	QUERY_DEBUG_INTERFACE(IDebugDataSpaces, &this->m_debugDataSpaces);
+	// The TTD adapter opens a trace directly instead of going through
+	// DbgEngAdapter::ConnectToDebugServerInternal(), so these have to be queried here too, otherwise
+	// they stay null and everything built on them (e.g. GetMemoryMap()) silently does nothing.
+	QUERY_DEBUG_INTERFACE(IDebugDataSpaces2, &this->m_debugDataSpaces2);
+	QUERY_DEBUG_INTERFACE(IDebugDataSpaces4, &this->m_debugDataSpaces4);
 	QUERY_DEBUG_INTERFACE(IDebugRegisters, &this->m_debugRegisters);
 	QUERY_DEBUG_INTERFACE(IDebugSymbols3, &this->m_debugSymbols);
 	QUERY_DEBUG_INTERFACE(IDebugSystemObjects, &this->m_debugSystemObjects);
@@ -185,6 +190,8 @@ void DbgEngTTDAdapter::Reset()
 	// we should keep everything active.
 	SAFE_RELEASE(this->m_debugControl);
 	SAFE_RELEASE(this->m_debugDataSpaces);
+	SAFE_RELEASE(this->m_debugDataSpaces2);
+	SAFE_RELEASE(this->m_debugDataSpaces4);
 	SAFE_RELEASE(this->m_debugRegisters);
 	SAFE_RELEASE(this->m_debugSymbols);
 	SAFE_RELEASE(this->m_dataModelManager);


### PR DESCRIPTION
Fixes #1141.

`DbgEngTTDAdapter::Start()` creates its own `IDebugClient7` and queries the interfaces it needs, but `IDebugDataSpaces2` was only ever queried by the base class in `DbgEngAdapter::ConnectToDebugServerInternal()` — a path the TTD adapter never takes, since it opens the trace with `OpenDumpFile()`. `m_debugDataSpaces2` therefore stayed `nullptr` for the entire TTD session, and code depending on it silently did nothing instead of failing visibly. `GetMemoryMap()` is the reachable case: it returns early on `if (!m_debugDataSpaces2)`, so under TTD it never called into dbgeng at all.

This also queries `IDebugDataSpaces4` on both the live-debug and TTD paths. Unlike `QueryVirtual`, `IDebugDataSpaces4`'s `GetValidRegionVirtual` / `GetNextDifferentlyValidOffsetVirtual` / `GetOffsetInformation` do work against a TTD trace and are useful for validating whether a given address range is present.

### What this does not do

It does **not** fix the empty memory map widget (#1132). `IDebugDataSpaces2::QueryVirtual` — which `GetMemoryMap()` walks — is unimplemented for TTD replay targets and returns `E_UNEXPECTED` even for an address whose bytes read back fine. WinDbg's own `!address` and `!vprot` are equally blank on a trace. Full analysis: https://github.com/Vector35/debugger/issues/1132#issuecomment-5072450325

So this is the latent half of that investigation: worth landing on its own so the interfaces are actually available and the null-pointer path stops masking real engine behavior.

### Testing

- Live DbgEng debugging: no behavior change expected. That path already queried `IDebugDataSpaces2`; `IDebugDataSpaces4` is purely additive.
- Both `IDebugDataSpaces2` and `IDebugDataSpaces4` were confirmed to `QueryInterface` successfully (`S_OK`) against a TTD trace using the pinned WinDbg's `dbgeng.dll` (TTD 1.01.11, release 1.11.592.0), via a standalone harness. This matters because `QUERY_DEBUG_INTERFACE` throws on failure — both interfaces are long-standing and were observed present.
- **Not built in-tree**: this checkout has no `BN_API_PATH` and no Qt 6.11.1, so the plugin was not compiled. The changes are 10 lines following the exact pattern of the adjacent `QUERY_DEBUG_INTERFACE` / `SAFE_RELEASE` lines, but CI should be the real check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
