### PR TITLE
Reject a TTD launch with no trace specified (Fixes #910)

### DIFF
--- a/core/adapters/dbgengttdadapter.cpp
+++ b/core/adapters/dbgengttdadapter.cpp
@@ -31,7 +31,7 @@ bool DbgEngTTDAdapter::ExecuteWithArgsInternal(const std::string& path, const st
 	// HRESULT, so check it up front. The UI blocks this in the adapter settings dialog; this covers the
 	// headless and scripted paths, plus the launches where that dialog is skipped.
 	std::error_code ec;
-	if (tracePath.empty() || !std::filesystem::exists(tracePath, ec))
+	if (tracePath.empty() || !std::filesystem::is_regular_file(tracePath, ec))
 	{
 		DebuggerEvent event;
 		event.type = LaunchFailureEventType;
@@ -41,11 +41,17 @@ bool DbgEngTTDAdapter::ExecuteWithArgsInternal(const std::string& path, const st
 				"settings, or record a new trace first.";
 			event.data.errorData.shortError = "No TTD trace specified";
 		}
-		else
+		else if (!std::filesystem::exists(tracePath, ec))
 		{
 			event.data.errorData.error = fmt::format("The TTD trace \"{}\" does not exist. Set the trace path in "
 				"the debug adapter settings.", tracePath);
 			event.data.errorData.shortError = "TTD trace not found";
+		}
+		else
+		{
+			event.data.errorData.error = fmt::format("The TTD trace path \"{}\" is not a file. Set the trace path in "
+				"the debug adapter settings to a recorded trace file.", tracePath);
+			event.data.errorData.shortError = "TTD trace is not a file";
 		}
 		PostDebuggerEvent(event);
 		return false;

--- a/core/adapters/dbgengttdadapter.cpp
+++ b/core/adapters/dbgengttdadapter.cpp
@@ -27,6 +27,30 @@ bool DbgEngTTDAdapter::ExecuteWithArgsInternal(const std::string& path, const st
 	scope = SettingsResourceScope;
 	auto inputFile = adapterSettings->Get<std::string>("common.inputFile", data, &scope);
 
+	// A trace is not optional for replay, but a missing one only surfaces later as an opaque OpenDumpFile
+	// HRESULT, so check it up front. The UI blocks this in the adapter settings dialog; this covers the
+	// headless and scripted paths, plus the launches where that dialog is skipped.
+	std::error_code ec;
+	if (tracePath.empty() || !std::filesystem::exists(tracePath, ec))
+	{
+		DebuggerEvent event;
+		event.type = LaunchFailureEventType;
+		if (tracePath.empty())
+		{
+			event.data.errorData.error = "No TTD trace specified. Set the trace path in the debug adapter "
+				"settings, or record a new trace first.";
+			event.data.errorData.shortError = "No TTD trace specified";
+		}
+		else
+		{
+			event.data.errorData.error = fmt::format("The TTD trace \"{}\" does not exist. Set the trace path in "
+				"the debug adapter settings.", tracePath);
+			event.data.errorData.shortError = "TTD trace not found";
+		}
+		PostDebuggerEvent(event);
+		return false;
+	}
+
     if (this->m_dbgengInitialized) {
         this->Reset();
     }

--- a/ui/adaptersettings.cpp
+++ b/ui/adaptersettings.cpp
@@ -183,11 +183,20 @@ bool AdapterSettingsDialog::validateSettings()
 	}
 
 	std::error_code ec;
-	if (!std::filesystem::exists(tracePath, ec))
+	if (!std::filesystem::is_regular_file(tracePath, ec))
 	{
-		QMessageBox::warning(this, "Trace Not Found",
-			QString("The trace file\n\n%1\n\ndoes not exist. Set \"Trace Path\" in the launch settings to an "
-				"existing trace.").arg(QString::fromStdString(tracePath)));
+		if (!std::filesystem::exists(tracePath, ec))
+		{
+			QMessageBox::warning(this, "Trace Not Found",
+				QString("The trace file\n\n%1\n\ndoes not exist. Set \"Trace Path\" in the launch settings to an "
+					"existing trace.").arg(QString::fromStdString(tracePath)));
+		}
+		else
+		{
+			QMessageBox::warning(this, "Invalid Trace",
+				QString("The trace path\n\n%1\n\nis not a file. Set \"Trace Path\" in the launch settings to a "
+					"recorded trace file.").arg(QString::fromStdString(tracePath)));
+		}
 		return false;
 	}
 

--- a/ui/adaptersettings.cpp
+++ b/ui/adaptersettings.cpp
@@ -18,13 +18,15 @@ limitations under the License.
 #include "uicontext.h"
 #include "qfiledialog.h"
 #include "settingsview.h"
+#include <QMessageBox>
+#include <filesystem>
 
 using namespace BinaryNinjaDebuggerAPI;
 using namespace BinaryNinja;
 using namespace std;
 
 AdapterSettingsDialog::AdapterSettingsDialog(QWidget* parent, DbgRef<DebuggerController> controller, const std::string& highlightGroup) :
-	QDialog(), m_controller(controller)
+	QDialog(), m_controller(controller), m_highlightGroup(highlightGroup)
 {
 	setWindowTitle("Debug Adapter Settings");
 	setAttribute(Qt::WA_DeleteOnClose);
@@ -158,8 +160,46 @@ QWidget* AdapterSettingsDialog::getWidgetForAdapter(const QString& adapter)
 }
 
 
+// The settings view writes each value as it is edited, so the current values can be read straight back from the
+// adapter settings here. Only the settings whose absence is guaranteed to fail the operation are checked, so that
+// the dialog does not get in the way of anything the adapter itself is willing to accept.
+bool AdapterSettingsDialog::validateSettings()
+{
+	if ((m_highlightGroup != "launch") || (m_adapterEntry->currentText() != "DBGENG_TTD"))
+		return true;
+
+	auto adapterSettings = m_controller->GetAdapterSettings();
+	if (!adapterSettings)
+		return true;
+
+	BNSettingsScope scope = SettingsResourceScope;
+	auto tracePath = adapterSettings->Get<std::string>("launch.trace_path", m_controller->GetData(), &scope);
+	if (tracePath.empty())
+	{
+		QMessageBox::warning(this, "No Trace Specified",
+			"The TTD adapter replays a previously recorded trace, so a trace path is required.\n\n"
+			"Set \"Trace Path\" in the launch settings, or record a new trace first.");
+		return false;
+	}
+
+	std::error_code ec;
+	if (!std::filesystem::exists(tracePath, ec))
+	{
+		QMessageBox::warning(this, "Trace Not Found",
+			QString("The trace file\n\n%1\n\ndoes not exist. Set \"Trace Path\" in the launch settings to an "
+				"existing trace.").arg(QString::fromStdString(tracePath)));
+		return false;
+	}
+
+	return true;
+}
+
+
 void AdapterSettingsDialog::apply()
 {
+	if (!validateSettings())
+		return;
+
 	if (m_useSameSettingsCheckbox)
 		m_controller->SetShowAdapterSettingsNextTime(!m_useSameSettingsCheckbox->isChecked());
 	accept();

--- a/ui/adaptersettings.h
+++ b/ui/adaptersettings.h
@@ -43,8 +43,10 @@ private:
 	QMap<QString, QWidget*> m_viewMap;
 	QLabel* m_noSettingsLabel;
 	QCheckBox* m_useSameSettingsCheckbox = nullptr;
+	std::string m_highlightGroup;
 
 	QWidget* getWidgetForAdapter(const QString& adapter);
+	bool validateSettings();
 
 public:
 	AdapterSettingsDialog(QWidget* parent, DbgRef<DebuggerController> controller, const std::string& highlightGroup = "");


### PR DESCRIPTION
Fixes #910.

This PR fails the TTD launch attempt and gives a meaningful error message (rather than the cryptic OpenDumpFile failed with xxxxx)

The check are both added in the UI and the debug adapter


