### PR TITLE
Use non-throwing filesystem checks

### DIFF
--- a/core/adapters/dbgengadapter.cpp
+++ b/core/adapters/dbgengadapter.cpp
@@ -48,23 +48,24 @@ static bool IsValidDbgEngPaths(const std::string& path)
 	if (path.empty())
 		return false;
 
+	std::error_code ec;
 	auto enginePath = filesystem::path(path);
-	if (!filesystem::exists(enginePath))
+	if (!filesystem::exists(enginePath, ec))
 		return false;
 
-	if (!filesystem::exists(enginePath / "dbgeng.dll"))
+	if (!filesystem::exists(enginePath / "dbgeng.dll", ec))
 		return false;
 
-	if (!filesystem::exists(enginePath / "dbghelp.dll"))
+	if (!filesystem::exists(enginePath / "dbghelp.dll", ec))
 		return false;
 
-	if (!filesystem::exists(enginePath / "dbgmodel.dll"))
+	if (!filesystem::exists(enginePath / "dbgmodel.dll", ec))
 		return false;
 
-	if (!filesystem::exists(enginePath / "dbgcore.dll"))
+	if (!filesystem::exists(enginePath / "dbgcore.dll", ec))
 		return false;
 
-	if (!filesystem::exists(enginePath / "dbgsrv.exe"))
+	if (!filesystem::exists(enginePath / "dbgsrv.exe", ec))
 		return false;
 
 	return true;

--- a/core/adapters/windowsnativeadapter.cpp
+++ b/core/adapters/windowsnativeadapter.cpp
@@ -34,10 +34,11 @@ static std::string GetDbgHelpPathFromSettings()
 	auto settings = BinaryNinja::Settings::Instance();
 	std::string path = settings->Get<std::string>("debugger.x64dbgEngPath");
 
+	std::error_code ec;
 	if (!path.empty())
 	{
 		auto dbgHelpPath = std::filesystem::path(path) / "dbghelp.dll";
-		if (std::filesystem::exists(dbgHelpPath))
+		if (std::filesystem::exists(dbgHelpPath, ec))
 			return dbgHelpPath.string();
 	}
 
@@ -49,7 +50,7 @@ static std::string GetDbgHelpPathFromSettings()
 		pluginRoot = BinaryNinja::GetBundledPluginDirectory();
 
 	auto bundledPath = std::filesystem::path(pluginRoot) / "dbgeng" / "amd64" / "dbghelp.dll";
-	if (std::filesystem::exists(bundledPath))
+	if (std::filesystem::exists(bundledPath, ec))
 		return bundledPath.string();
 
 	return "";

--- a/core/windbginstaller.cpp
+++ b/core/windbginstaller.cpp
@@ -36,9 +36,11 @@ std::string GetInstallerPath() {
         pluginRoot = GetBundledPluginDirectory();
 
     if (!pluginRoot.empty()) {
+        std::error_code ec;
         fs::path path = fs::path(pluginRoot) / "windbg-installer.exe";
-        if (fs::exists(path)) {
-            return fs::canonical(path).string();
+        if (fs::exists(path, ec)) {
+            fs::path canonicalPath = fs::canonical(path, ec);
+            return ec ? path.string() : canonicalPath.string();
         }
     }
 
@@ -60,8 +62,9 @@ bool IsWinDbgInstalled(const std::string& installPath) {
     }
 
     /* Check for required DLLs */
-    return fs::exists(path + "\\amd64\\dbgeng.dll") &&
-           fs::exists(path + "\\amd64\\dbghelp.dll");
+    std::error_code ec;
+    return fs::exists(path + "\\amd64\\dbgeng.dll", ec) &&
+           fs::exists(path + "\\amd64\\dbghelp.dll", ec);
 }
 
 InstallResult InstallWinDbg(const std::string& installPath, bool isUpdate) {
@@ -152,7 +155,8 @@ InstallResult InstallWinDbg(const std::string& installPath, bool isUpdate) {
             }
 
             /* Clean up result file */
-            fs::remove(resultPath);
+            std::error_code ec;
+            fs::remove(resultPath, ec);
         }
 
         LogError("Installation failed: %s", errorMessage.c_str());

--- a/ui/controlswidget.cpp
+++ b/ui/controlswidget.cpp
@@ -209,8 +209,11 @@ bool DebugControlsWidget::handleContainerFile()
 	auto data = m_controller->GetData();
 	auto file = data->GetFile();
 
+	// Use the non-throwing overloads of fs::exists, since the throwing ones can raise a
+	// filesystem_error (e.g. EACCES from posix_stat) for inaccessible paths
+	std::error_code ec;
 	std::string execPath = m_controller->GetExecutablePath();
-	if (!execPath.empty() && fs::exists(execPath))
+	if (!execPath.empty() && fs::exists(execPath, ec))
 		return true;
 
 	std::string currentPath = file->GetFilename();
@@ -227,7 +230,7 @@ bool DebugControlsWidget::handleContainerFile()
 	if (originalPath.empty())
 		return true;
 
-	if (fs::exists(originalPath))
+	if (fs::exists(originalPath, ec))
 		return true;
 
 	auto prompt = QString(
@@ -239,7 +242,7 @@ bool DebugControlsWidget::handleContainerFile()
 	if (QMessageBox::question(this, "File Not Found", prompt) != QMessageBox::Yes)
 		return false;
 
-	fs::path defaultPath = fs::current_path() / fs::path(originalPath).filename();
+	fs::path defaultPath = fs::current_path(ec) / fs::path(originalPath).filename();
 	if (isBndb)
 		defaultPath = fs::path(currentPath).parent_path() / fs::path(originalPath).filename();
 

--- a/ui/ttdrecord.cpp
+++ b/ui/ttdrecord.cpp
@@ -278,14 +278,15 @@ static bool IsValidDbgEngTTDPaths(const std::string& path)
 	if (path.empty())
 		return false;
 
+	std::error_code ec;
 	auto enginePath = filesystem::path(path);
-	if (!filesystem::exists(enginePath))
+	if (!filesystem::exists(enginePath, ec))
 		return false;
 
-	if (!filesystem::exists(enginePath / "TTD.exe"))
+	if (!filesystem::exists(enginePath / "TTD.exe", ec))
 		return false;
 
-	if (!filesystem::exists(enginePath / "TTDRecord.dll"))
+	if (!filesystem::exists(enginePath / "TTDRecord.dll", ec))
 		return false;
 
 	return true;

--- a/ui/ui.cpp
+++ b/ui/ui.cpp
@@ -1610,7 +1610,8 @@ void GlobalDebuggerUI::installTTD(const UIActionContext& ctxt)
 	LogDebug("installTarget: %s", installPath.c_str());
 
 	// Check if WinDbg is already installed
-	if (std::filesystem::exists(installTarget) && IsWinDbgInstalled(installPath))
+	std::error_code ec;
+	if (std::filesystem::exists(installTarget, ec) && IsWinDbgInstalled(installPath))
 	{
 		// Get installed version
 		std::string installedVersion = GetWinDbgInstalledVersion(installPath);


### PR DESCRIPTION
Switch unguarded `fs::exists`/`canonical`/`remove`/`current_path` calls to the `std::error_code` overloads so an inaccessible path (EACCES etc.) is treated as non-existent instead of terminating the process.

Fixes #1163
Fixes BINARYNINJA-HC