### PR TITLE
Invalidate the register cache after a successful register write

### DIFF
--- a/core/adapters/corelliumadapter.cpp
+++ b/core/adapters/corelliumadapter.cpp
@@ -627,8 +627,11 @@ bool CorelliumAdapter::WriteRegister(const std::string& reg, intx::uint512 value
                                             : uint512ToLittleEndianHex(value, this->m_registerInfo[reg].m_bitSize / 8);
     const auto reply = this->m_rspConnector->TransmitAndReceive(RspData("P{:02X}={}",
                 this->m_registerInfo[reg].m_regNum, newRegString));
-    if (reply.m_data[0])
+    if (reply.AsString() == "OK")
+    {
+        InvalidateCache();
         return true;
+    }
 
     char query{'g'};
     const auto generic_query = this->m_rspConnector->TransmitAndReceive(RspData(&query, sizeof(query)));

--- a/core/adapters/esrevenadapter.cpp
+++ b/core/adapters/esrevenadapter.cpp
@@ -1064,8 +1064,11 @@ bool EsrevenAdapter::WriteRegister(const std::string& reg, intx::uint512 value)
     const auto reply = this->m_rspConnector->TransmitAndReceive(RspData("P{:02X}={}",
                                        this->m_registerInfo[reg].m_regNum, newRegString));
 
-    if (reply.m_data[0])
+    if (reply.AsString() == "OK")
+    {
+        InvalidateCache();
         return true;
+    }
 
     char query{'g'};
     const auto generic_query = this->m_rspConnector->TransmitAndReceive(RspData(&query, sizeof(query)));

--- a/core/adapters/gdbadapter.cpp
+++ b/core/adapters/gdbadapter.cpp
@@ -660,8 +660,11 @@ bool GdbAdapter::WriteRegister(const std::string& reg, intx::uint512 value)
                                             : uint512ToLittleEndianHex(value, this->m_registerInfo[reg].m_bitSize / 8);
     const auto reply = this->m_rspConnector->TransmitAndReceive(RspData("P{:02X}={}",
                                        this->m_registerInfo[reg].m_regNum, newRegString));
-    if (reply.m_data[0])
+    if (reply.AsString() == "OK")
+    {
+        InvalidateCache();
         return true;
+    }
 
     char query{'g'};
     const auto generic_query = this->m_rspConnector->TransmitAndReceive(RspData(&query, sizeof(query)));


### PR DESCRIPTION
Fixes #1172

`WriteRegister` did not invalidate the register cache after a successful `P` write, so
`ReadRegister` kept returning the pre-write value until a step or resume cleared it.
Editing a register looked like it did nothing.

Also check the reply is `"OK"` rather than non-empty: RSP answers `E xx` on failure and
`'E'` is non-zero, so failed writes were reported as successful. An empty reply means `P`
is unsupported and still falls through to the `G` fallback.

Same three lines in the Corellium, GDB and esReven adapters, so all three are fixed.

Verified on a live Corellium device: `WriteRegister("x0")` now reads back what it wrote.