### PR TITLE
Remove the 100x Release() loop from the DbgEng adapters' Reset()

### DIFF
--- a/core/adapters/dbgengttdadapter.cpp
+++ b/core/adapters/dbgengttdadapter.cpp
@@ -203,8 +203,14 @@ bool DbgEngTTDAdapter::Start()
 
 void DbgEngTTDAdapter::Reset()
 {
+	// The base class takes this lock so that Reset() cannot tear the interfaces down while EngineLoop()
+	// is still using them. This override has to do the same, otherwise a Reset() coming from a relaunch
+	// races the Reset() that EngineLoop() itself performs when the target exits. The mutex is recursive,
+	// so the EngineLoop() -> Reset() path does not deadlock.
+	std::unique_lock lock(m_engineLoopMutex);
+
 	m_aboutToBeKilled = false;
-	
+
 	// Clear TTD events cache when resetting
 	ClearTTDEventsCache();
 
@@ -217,6 +223,7 @@ void DbgEngTTDAdapter::Reset()
 	SAFE_RELEASE(this->m_debugDataSpaces);
 	SAFE_RELEASE(this->m_debugRegisters);
 	SAFE_RELEASE(this->m_debugSymbols);
+	SAFE_RELEASE(this->m_debugSystemObjects);
 	SAFE_RELEASE(this->m_dataModelManager);
 	SAFE_RELEASE(this->m_modelMgr);
 	SAFE_RELEASE(this->m_debugHost);
@@ -227,17 +234,6 @@ void DbgEngTTDAdapter::Reset()
 		this->m_debugClient->EndSession(DEBUG_END_PASSIVE);
 		m_server = 0;
 	}
-
-	// There seems to be an internal ref-counting issue in the DbgEng TTD engine, that the reference for the debug
-	// client is not properly freed after the target has exited. To properly free the debug client instance, here we
-	// are calling Release() a few more times to ensure the ref count goes down to 0. Luckily this would not cause
-	// a UAF or crash.
-	// This might be related to the weird behavior of not terminating the target when we call TerminateProcesses(),
-	// (see comment in `DbgEngTTDAdapter::Quit()`).
-	// The same issue is not observed when we do forward debugging using the regular DbgEng. Also, I cannot reproduce
-	// the issue using my script https://github.com/xusheng6/dbgeng_test.
-	for (size_t i = 0; i < 100; i++)
-		m_debugClient->Release();
 
 	SAFE_RELEASE(this->m_debugClient);
 

--- a/core/adapters/dbgengttdadapter.h
+++ b/core/adapters/dbgengttdadapter.h
@@ -104,10 +104,10 @@ namespace BinaryNinjaDebugger {
 		std::optional<TTDRegisterWriteEvent> ParseSingleTTDRegisterWriteObject(const std::string& expression, const std::string& reg);
 
 		// Data model interfaces for TTD
-		IHostDataModelAccess* m_dataModelManager;
-    	IDataModelManager* m_modelMgr;
-		IDebugHost* m_debugHost;
-		IDebugHostEvaluator* m_hostEvaluator;
+		IHostDataModelAccess* m_dataModelManager {nullptr};
+    	IDataModelManager* m_modelMgr {nullptr};
+		IDebugHost* m_debugHost {nullptr};
+		IDebugHostEvaluator* m_hostEvaluator {nullptr};
     };
 
     class DbgEngTTDAdapterType : public DebugAdapterType

--- a/core/adapters/localwindowskerneladapter.cpp
+++ b/core/adapters/localwindowskerneladapter.cpp
@@ -115,6 +115,10 @@ bool LocalWindowsKernelAdapter::Start()
 
 void LocalWindowsKernelAdapter::Reset()
 {
+	// Same reason as the base class: keep Reset() from tearing the interfaces down underneath
+	// EngineLoop(). The mutex is recursive, so the EngineLoop() -> Reset() path does not deadlock.
+	std::unique_lock lock(m_engineLoopMutex);
+
 	m_aboutToBeKilled = false;
 
 	if (!this->m_dbgengInitialized)
@@ -133,17 +137,6 @@ void LocalWindowsKernelAdapter::Reset()
 		this->m_debugClient->EndSession(DEBUG_END_PASSIVE);
 		m_server = 0;
 	}
-
-	// There seems to be an internal ref-counting issue in the DbgEng TTD engine, that the reference for the debug
-	// client is not properly freed after the target has exited. To properly free the debug client instance, here we
-	// are calling Release() a few more times to ensure the ref count goes down to 0. Luckily this would not cause
-	// a UAF or crash.
-	// This might be related to the weird behavior of not terminating the target when we call TerminateProcesses(),
-	// (see comment in `DbgEngTTDAdapter::Quit()`).
-	// The same issue is not observed when we do forward debugging using the regular DbgEng. Also, I cannot reproduce
-	// the issue using my script https://github.com/xusheng6/dbgeng_test.
-	for (size_t i = 0; i < 100; i++)
-		m_debugClient->Release();
 
 	SAFE_RELEASE(this->m_debugClient);
 

--- a/core/adapters/windowsdumpfile.cpp
+++ b/core/adapters/windowsdumpfile.cpp
@@ -127,6 +127,10 @@ bool WindowsDumpFileAdapter::Start()
 
 void WindowsDumpFileAdapter::Reset()
 {
+	// Same reason as the base class: keep Reset() from tearing the interfaces down underneath
+	// EngineLoop(). The mutex is recursive, so the EngineLoop() -> Reset() path does not deadlock.
+	std::unique_lock lock(m_engineLoopMutex);
+
 	m_aboutToBeKilled = false;
 
 	if (!this->m_dbgengInitialized)
@@ -145,17 +149,6 @@ void WindowsDumpFileAdapter::Reset()
 		this->m_debugClient->EndSession(DEBUG_END_PASSIVE);
 		m_server = 0;
 	}
-
-	// There seems to be an internal ref-counting issue in the DbgEng TTD engine, that the reference for the debug
-	// client is not properly freed after the target has exited. To properly free the debug client instance, here we
-	// are calling Release() a few more times to ensure the ref count goes down to 0. Luckily this would not cause
-	// a UAF or crash.
-	// This might be related to the weird behavior of not terminating the target when we call TerminateProcesses(),
-	// (see comment in `DbgEngTTDAdapter::Quit()`).
-	// The same issue is not observed when we do forward debugging using the regular DbgEng. Also, I cannot reproduce
-	// the issue using my script https://github.com/xusheng6/dbgeng_test.
-	for (size_t i = 0; i < 100; i++)
-		m_debugClient->Release();
 
 	SAFE_RELEASE(this->m_debugClient);
 

--- a/core/adapters/windowskerneladapter.cpp
+++ b/core/adapters/windowskerneladapter.cpp
@@ -148,6 +148,10 @@ bool WindowsKernelAdapter::Start()
 
 void WindowsKernelAdapter::Reset()
 {
+	// Same reason as the base class: keep Reset() from tearing the interfaces down underneath
+	// EngineLoop(). The mutex is recursive, so the EngineLoop() -> Reset() path does not deadlock.
+	std::unique_lock lock(m_engineLoopMutex);
+
 	m_aboutToBeKilled = false;
 
 	if (!this->m_dbgengInitialized)
@@ -166,17 +170,6 @@ void WindowsKernelAdapter::Reset()
 		this->m_debugClient->EndSession(DEBUG_END_PASSIVE);
 		m_server = 0;
 	}
-
-	// There seems to be an internal ref-counting issue in the DbgEng TTD engine, that the reference for the debug
-	// client is not properly freed after the target has exited. To properly free the debug client instance, here we
-	// are calling Release() a few more times to ensure the ref count goes down to 0. Luckily this would not cause
-	// a UAF or crash.
-	// This might be related to the weird behavior of not terminating the target when we call TerminateProcesses(),
-	// (see comment in `DbgEngTTDAdapter::Quit()`).
-	// The same issue is not observed when we do forward debugging using the regular DbgEng. Also, I cannot reproduce
-	// the issue using my script https://github.com/xusheng6/dbgeng_test.
-	for (size_t i = 0; i < 100; i++)
-		m_debugClient->Release();
 
 	SAFE_RELEASE(this->m_debugClient);
 


### PR DESCRIPTION
The debug client only owes one `Release()`. Calling it 100 times destroys the client part way through the loop and runs the remaining calls on freed memory — the crash in #1082.

Measured over a TTD session on WinDbg 1.2402, 1.2603 and 1.2606: a single `Release()` destroys the client. Only the first session in a process leaves references behind (`OpenDumpFile` takes two the engine keeps), and that does not grow per session, hold the trace file open, or stop a later session from starting.

The same loop had been copy-pasted into the dump file and both kernel adapters; all four are fixed. Also takes `m_engineLoopMutex` in these overrides as the base class does, and releases the `IDebugSystemObjects` the TTD override was missing.

Fixes #1082

🤖 Generated with [Claude Code](https://claude.com/claude-code)