### PR TITLE
Terminate the TTD target on the engine thread

### DIFF
--- a/core/adapters/dbgengadapter.cpp
+++ b/core/adapters/dbgengadapter.cpp
@@ -708,6 +708,14 @@ void DbgEngAdapter::EngineLoop()
 				// WaitForEvent(). The real purpose of this call is to wait until the UI/API initiates another control
 				// operation, which then calls ExitDispatch(), which causes the DispatchCallbacks() to return.
 				m_debugClient->DispatchCallbacks(INFINITE);
+
+				// A DbgEng client belongs to the thread that created it, and ExitDispatch() is the only call
+				// documented as safe to make from another thread. So Quit() only raises this flag and wakes us
+				// up; the terminate itself has to happen here. Doing it from the requesting thread while this
+				// one sits in DispatchCallbacks() faults inside WinDbg's data model JS provider on 1.2606
+				// (#1129).
+				if (m_terminateRequested.exchange(false))
+					TerminateTargetOnEngineThread();
 			}
 			// TODO: add step branch and step backs
 			else if ((execution_status == DEBUG_STATUS_GO) || (execution_status == DEBUG_STATUS_STEP_INTO)
@@ -907,6 +915,15 @@ bool DbgEngAdapter::Detach()
 	m_debugClient->ExitDispatch(reinterpret_cast<PDEBUG_CLIENT>(m_debugClient));
 	return true;
 }
+
+bool DbgEngAdapter::TerminateTargetOnEngineThread()
+{
+	if (!this->m_debugClient)
+		return false;
+
+	return this->m_debugClient->TerminateProcesses() == S_OK;
+}
+
 
 bool DbgEngAdapter::Quit()
 {

--- a/core/adapters/dbgengadapter.cpp
+++ b/core/adapters/dbgengadapter.cpp
@@ -655,6 +655,11 @@ void DbgEngAdapter::EngineLoop()
 	bool outputStateOnStop = settings->Get<bool>("debugger.dbgEngOutputStateOnStop");
 
 	m_lastExecutionStatus = DEBUG_STATUS_NO_DEBUGGEE;
+	// The controller reuses one adapter object across launches, so a terminate request that the previous
+	// session left unserviced (it exited on its own before we picked the request up) would otherwise be
+	// latched here and kill this target. The worker queue cannot deliver a Quit() until the launch
+	// operation completes, which needs the stop event posted below, so no live request can be lost here.
+	m_terminateRequested = false;
 	bool finished = false;
 	while (true)
 	{
@@ -714,8 +719,10 @@ void DbgEngAdapter::EngineLoop()
 				// up; the terminate itself has to happen here. Doing it from the requesting thread while this
 				// one sits in DispatchCallbacks() faults inside WinDbg's data model JS provider on 1.2606
 				// (#1129).
-				if (m_terminateRequested.exchange(false))
-					TerminateTargetOnEngineThread();
+				if (m_terminateRequested.exchange(false) && !TerminateTargetOnEngineThread())
+					// Quit() has already reported success to its caller, so this is the only place the
+					// failure can be surfaced.
+					LogWarn("Failed to terminate the target");
 			}
 			// TODO: add step branch and step backs
 			else if ((execution_status == DEBUG_STATUS_GO) || (execution_status == DEBUG_STATUS_STEP_INTO)

--- a/core/adapters/dbgengadapter.h
+++ b/core/adapters/dbgengadapter.h
@@ -162,7 +162,9 @@ namespace BinaryNinjaDebugger {
 		bool m_aboutToBeKilled = false;
 
 		// Raised by Quit() so that EngineLoop() performs the terminate on the thread that owns the
-		// debug client. See TerminateTargetOnEngineThread().
+		// debug client. See TerminateTargetOnEngineThread(). EngineLoop() clears it when a session
+		// starts, since the adapter object outlives a session and an unserviced request would
+		// otherwise be latched into the next one.
 		std::atomic<bool> m_terminateRequested {false};
 
         std::string m_pdbFileName {};

--- a/core/adapters/dbgengadapter.h
+++ b/core/adapters/dbgengadapter.h
@@ -21,6 +21,7 @@ limitations under the License.
 #define NOMINMAX
 #include <windows.h>
 #include <dbgeng.h>
+#include <atomic>
 #include <chrono>
 
 namespace BinaryNinjaDebugger {
@@ -138,6 +139,10 @@ namespace BinaryNinjaDebugger {
 		virtual bool Start();
 		virtual void Reset();
 
+		// Kills the target. Called by EngineLoop() on the thread that created the debug client, never
+		// directly from Quit(), because DbgEng clients are thread-affine.
+		virtual bool TerminateTargetOnEngineThread();
+
 		std::vector<DebugBreakpoint> m_debug_breakpoints {};
 		bool m_lastOperationIsStepInto = false;
 
@@ -155,6 +160,10 @@ namespace BinaryNinjaDebugger {
 		bool m_dbgSrvLaunchedByAdapter = false;
 
 		bool m_aboutToBeKilled = false;
+
+		// Raised by Quit() so that EngineLoop() performs the terminate on the thread that owns the
+		// debug client. See TerminateTargetOnEngineThread().
+		std::atomic<bool> m_terminateRequested {false};
 
         std::string m_pdbFileName {};
         bool m_usePDBFileName = true;

--- a/core/adapters/dbgengttdadapter.cpp
+++ b/core/adapters/dbgengttdadapter.cpp
@@ -303,6 +303,17 @@ bool DbgEngTTDAdapter::SupportFeature(DebugAdapterCapacity feature)
 }
 
 
+bool DbgEngTTDAdapter::TerminateTargetOnEngineThread()
+{
+	if (!this->m_debugClient)
+		return false;
+
+	// I am not sure why TerminateProcesses() would not work. It just let the target run freely till the end of the
+	// trace and not terminating the process at all.
+	return this->m_debugClient->TerminateCurrentProcess() == S_OK;
+}
+
+
 bool DbgEngTTDAdapter::Quit()
 {
 	m_aboutToBeKilled = true;
@@ -310,10 +321,17 @@ bool DbgEngTTDAdapter::Quit()
 	if (!this->m_debugClient)
 		return false;
 
-	// I am not sure why TerminateProcesses() would not work. It just let the target run freely till the end of the
-	// trace and not terminating the process at all.
-	if (this->m_debugClient->TerminateCurrentProcess() != S_OK)
-		return false;
+	// Terminating from this thread crashes inside WinDbg's data model JS provider on 1.2606 (#1129):
+	// the engine thread owns the debug client and is parked in DispatchCallbacks(), and DbgEng clients
+	// are thread-affine. Ask that thread to do it and wake it up; ExitDispatch() is the one call that is
+	// documented as safe to make from here.
+	m_terminateRequested = true;
+
+	// If the trace is being replayed rather than sitting at a break, the engine thread is inside
+	// WaitForEvent() where ExitDispatch() will not reach it. SetInterrupt() is safe from any thread and
+	// brings it back to a break, where the request above is picked up.
+	if (m_debugControl && (ExecStatus() != DEBUG_STATUS_BREAK))
+		m_debugControl->SetInterrupt(DEBUG_INTERRUPT_ACTIVE);
 
 	m_debugClient->ExitDispatch(reinterpret_cast<PDEBUG_CLIENT>(m_debugClient));
 	return true;

--- a/core/adapters/dbgengttdadapter.h
+++ b/core/adapters/dbgengttdadapter.h
@@ -36,6 +36,7 @@ namespace BinaryNinjaDebugger {
 
 		bool Start() override;
 		void Reset() override;
+		bool TerminateTargetOnEngineThread() override;
 
         bool GoReverse() override;
         bool StepIntoReverse() override;


### PR DESCRIPTION
DbgEng clients are thread-affine, and `ExitDispatch()` is the only call documented as safe from another thread. `Quit()` was calling `TerminateCurrentProcess()` from the requesting thread while the engine thread sat in `DispatchCallbacks()`, which faults inside WinDbg 1.2606's new V8-based `JSProvider.dll`.

`Quit()` now only raises `m_terminateRequested` and wakes the engine loop, which performs the terminate itself.

Reproduced with a harness mirroring the adapter (callbacks, worker thread, engine loop): **5/5 crashes before, 0/10 after** on 1.2606, and 0/3 on 1.2603. WinDbg 1.2402 and 1.2603 never crashed either way, so the pinned version was already a valid mitigation.

Untested path: if the trace is replaying rather than sitting at a break, `Quit()` falls back to `SetInterrupt()`; the harness always stopped at a break.

Fixes #1129

🤖 Generated with [Claude Code](https://claude.com/claude-code)