### PR TITLE
Disable debugger.useMemoryMapSegments by default (#1158)

### DIFF
--- a/core/debugger.cpp
+++ b/core/debugger.cpp
@@ -159,8 +159,8 @@ static void RegisterSettings()
 		R"({
 			"title" : "Apply the target memory map as segments",
 			"type" : "boolean",
-			"default" : true,
-			"description" : "When enabled and the debug adapter reports a memory map, the debugger mirrors it into the binary view as one bounded segment per mapped region, which lets Find work during debugging (it only scans mapped memory). When disabled, the debugger falls back to a single overlay spanning the whole address space (the previous behavior). Adapters that do not report a memory map always use the overlay.",
+			"default" : false,
+			"description" : "When enabled and the debug adapter reports a memory map, the debugger mirrors it into the binary view as one bounded segment per mapped region, which lets Find work during debugging (it only scans mapped memory). This is off by default because querying the memory map on every stop is slow with adapters that report one region per request, e.g., LLDB. When disabled, the debugger uses a single overlay spanning the whole address space. Adapters that do not report a memory map always use the overlay.",
 			"ignore" : ["SettingsProjectScope", "SettingsResourceScope"]
 			})");
 

--- a/core/debuggercontroller.h
+++ b/core/debuggercontroller.h
@@ -118,7 +118,7 @@ namespace BinaryNinjaDebugger {
 		// Cached "debugger.useMemoryMapSegments" setting, sampled once when the debugger view is created
 		// (SyncMemoryRegions runs on every stop, so we do not want to hit Settings each time). When false,
 		// the debugger keeps the old blanket overlay instead of mirroring the backend memory map.
-		bool m_useMemoryMapSegments = true;
+		bool m_useMemoryMapSegments = false;
 		// This is the start address of the first file segments in the m_data. Unlike the return value of GetStart(),
 		// this does not change even if we add the debugger memory region. In the future, this should be provided by
 		// the binary view -- we will no longer need to track it ourselves

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -399,9 +399,10 @@ Writing to it will also cause the target's memory to change.
 
 The binary view can be accessed by the ``data`` property of the controller.
 
-Starting from 5.4.10157-dev (aba9ec4), when the debug adapter reports a memory map, these regions mirror it: one bounded
-region per mapped range, each with the target's page permissions, instead of a single region spanning the entire address
-space. They are listed as `debugger:<N>` in the Memory Map sidebar:
+Starting from 5.4.10157-dev (aba9ec4), the debugger can instead mirror the memory map reported by the debug adapter: one
+bounded region per mapped range, each with the target's page permissions, instead of a single region spanning the entire
+address space. This is opt-in via the `debugger.useMemoryMapSegments` setting described below. When it is on, the regions
+are listed as `debugger:<N>` in the Memory Map sidebar:
 
 ![](../../img/debugger/memory_map_segments.png)
 
@@ -413,10 +414,11 @@ The regions are refreshed when the target stops, but only rebuilt if the map cha
 target exits or you detach. LLDB, DbgEng, Windows Native, GDB, and GDB MI report a memory map; adapters that do not keep
 using the single whole-address-space region.
 
-The `debugger.useMemoryMapSegments` setting (`Apply the target memory map as segments`, enabled by default) selects
-between the two models. Disable it to always use the single region, which is worth doing for a target with so many
-mappings that rebuilding them slows down each stop. It is read when the session starts, so a change applies to the next
-launch/attach.
+The `debugger.useMemoryMapSegments` setting (`Apply the target memory map as segments`, disabled by default) selects
+between the two models. It is off by default because some adapters, notably LLDB, answer a memory map query with one
+round trip per region, which makes pulling the map on every stop noticeably slow. Enable it if you need `Find` while
+debugging and your target's map is small enough that rebuilding it does not slow down each stop. It is read when the
+session starts, so a change applies to the next launch/attach.
 
 The map is also available from the API, see [Reading the Target Memory Map](#reading-the-target-memory-map).
 


### PR DESCRIPTION
This is causing a pretty bad performance regression as documented in https://github.com/Vector35/debugger/issues/1158. There are various ways to fix it, but given we are in the latest stage of a release cycle, unfortunately there is not a better solution for it